### PR TITLE
Update flattentool

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -9,6 +9,7 @@ import csv
 import gzip
 from pprint import pprint
 import elasticsearch.helpers
+import time
 
 ES_INDEX = os.environ.get("ES_INDEX", "threesixtygiving")
 
@@ -160,6 +161,8 @@ def import_to_elasticsearch(files, clean):
         print('Updating existing index')
     else:
         pprint(result)
+
+    time.sleep(1)
 
     get_mapping_from_index(es)
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,6 @@ requests
 django-environ
 raven
 elasticsearch
--e git+https://github.com/OpenDataServices/flatten-tool.git@2af8a004d24e376e948d2f473753692ad6c248b8#egg=flattentool
+-e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool
 python-dateutil
 strict-rfc3339

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests==2.9.1
 django-environ==0.4.0
 raven==5.12.0
 elasticsearch==2.3.0
--e git+https://github.com/OpenDataServices/flatten-tool.git@2af8a004d24e376e948d2f473753692ad6c248b8#egg=flattentool-dev
+-e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool-dev
 python-dateutil==2.5.2
 strict-rfc3339==0.6
 ## The following requirements were added by pip --freeze:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ requests==2.9.1
 django-environ==0.4.0
 raven==5.12.0
 elasticsearch==2.3.0
--e git+https://github.com/OpenDataServices/flatten-tool.git@2af8a004d24e376e948d2f473753692ad6c248b8#egg=flattentool-dev
+-e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool-dev
 python-dateutil==2.5.2
 strict-rfc3339==0.6
 


### PR DESCRIPTION
Deployed at http://grantnav-updateflattentool.grantnav-dev.default.opendataservices.uk0.bigv.io/ for comparison with http://grantnav-dev.grantnav-dev.default.opendataservices.uk0.bigv.io/

Currently includes the commit from https://github.com/OpenDataServices/grantnav/pull/75 so might be easier to compare once that's merged and data is reloaded again.