### PR TITLE
[#99] Adds licence information about code-point data

### DIFF
--- a/LICENCE.rst
+++ b/LICENCE.rst
@@ -21,3 +21,13 @@ Copyright 2016 Open Data Services Co-operative Limited.
 
 
 
+Code-Point Open
+---------------
+
+GrantNav relies on Code-Point Open data <https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html> which is distributed under an Open Government Licence (v3) <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>
+
+Contains OS data © Crown copyright and database right 2016
+
+Contains Royal Mail data © Royal Mail copyright and Database right 2016
+
+Contains National Statistics data © Crown copyright and database right 2016  

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -58,6 +58,11 @@
         </div>
         <div class="row">
           <div class="col-sm-12">
+            <p id="code-point" class="footer-info">GrantNav relies on <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> data which is distributed under an <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>. <br/>Contains OS data &copy; Crown copyright and database right 2016<br/>Contains Royal Mail data &copy; Royal Mail copyright and Database right 2016<br/>Contains National Statistics data &copy; Crown copyright and database right 2016</p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-12">
             <p class="footer-info">360Giving is a company limited by guarantee (Company Number 9668396) and a registered charity (Charity Number 1164883)</p>
           </div>
         </div>

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -37,6 +37,17 @@ def test_home(dataload, server_url, browser):
     assert 'GrantNav' in browser.find_element_by_tag_name('body').text
 
 
+@pytest.mark.parametrize(('text'), [
+    ('Contains OS data © Crown copyright and database right 2016'),
+    ('Contains Royal Mail data © Royal Mail copyright and Database right 2016'),
+    ('Contains National Statistics data © Crown copyright and database right 2016')
+    ])
+def test_code_point_credit(dataload, server_url, browser, text):
+    browser.get(server_url)
+    code_point_paragraph = browser.find_element_by_id("code-point").text
+    assert text in code_point_paragraph
+    
+
 def test_search(dataload, server_url, browser):
     browser.get(server_url)
     browser.find_element_by_class_name("large-search-icon").click()


### PR DESCRIPTION
We need to do this under the terms of the licence of the data
Adds info to the licence document and also to the footer.
Adds a test to see that it is displayed on the home page

<!---
@huboard:{"order":112.0,"milestone_order":112,"custom_state":""}
-->
