### PR TITLE
[#61] [#174] Adds a terms and conditions page

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -80,3 +80,16 @@ a.anchor {
 .dtr-data {
   white-space: normal; 
 }
+
+.footer-menu {
+    margin-left: 5px;
+    padding: 0;
+}
+
+.footer-info {
+  margin-left: 5px;
+}
+
+.footer-menu a {
+    color: #fff;
+}

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -52,6 +52,12 @@
         </div>
         <div class="row">
           <div class="col-sm-12">
+            <ul id="menu-footer2" class="footer-menu"><li class="menu-item"><a href="{% url 'terms' %}">Terms and Conditions</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-12">
             <p class="footer-info">360Giving is a company limited by guarantee (Company Number 9668396) and a registered charity (Charity Number 1164883)</p>
           </div>
         </div>

--- a/grantnav/frontend/templates/terms.html
+++ b/grantnav/frontend/templates/terms.html
@@ -1,0 +1,120 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block main_content %}
+
+<div>
+  <h1>{% trans "Terms &amp; conditions" %}</h1>
+  <p>{% blocktrans %}This web application is free software designed to help people explore data published to the 360Giving Data Standard.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}It is offered as service WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.{% endblocktrans %}</p>
+  
+  <p>{% blocktrans %}The site is operated in partnership between Open Data Services Co-operative Limited and 360Giving.{% endblocktrans %}</p>
+  
+  <p>{% blocktrans %}If you continue to browse and use this website, you are agreeing to comply with and be bound by the following terms and conditions of use, which together with our privacy policy govern 360Giving and Open Data Services Co-operative Limited's relationship with you in relation to this website. If you disagree with any part of these terms and conditions, please do not use our website.{% endblocktrans %}</p>
+
+  <p>The term &#8216;360Giving&#8217; or &#8216;us&#8217; or &#8216;we&#8217; refers to the owner of the website. Our company registration number is 9668396. Our registered address is The Peak, 5 Wilton Road, London, SW1P 1AP. The term &#8216;you&#8217; refers to the user or viewer of our website.</p>
+
+  <p>{% blocktrans %}The term 'Open Data Services Co-operative Limited' refers to the operator of the website on behalf of 360Giving. Open Data Services Co-operative Limited's company registration number is 09506232. Their registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN. There is more company information on the <a href="https://opencorporates.com/companies/gb/09506232">Open Data Services Co-operative Limited page at Open Corporates</a>.{% endblocktrans %}</p>
+  
+
+  <p>{% blocktrans %}The use of this website is subject to the following terms of use:{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}The content of the pages of this website is for your general information and use only. It is subject to change without notice.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}Neither we nor any third parties provide any warranty or guarantee as to the accuracy, timeliness, performance, completeness or suitability of the information and materials found or offered on this website for any particular purpose. You acknowledge that such information and materials may contain inaccuracies or errors and we expressly exclude liability for any such inaccuracies or errors to the fullest extent permitted by law.<br>
+  Your use of any information or materials on this website is entirely at your own risk, for which we shall not be liable. It shall be your own responsibility to ensure that any products, services or information available through this website meet your specific requirements.<br>
+  This website contains material which is owned by or licensed to us. This material includes, but is not limited to, the design, layout, look, appearance and graphics. Reproduction is prohibited other than in accordance with the copyright notice, which forms part of these terms and conditions.<br>
+  All trademarks reproduced in this website which are not the property of, or licensed to, the operator are acknowledged on the website.<br>
+  Unauthorised use of this website may give rise to a claim for damages and/or be a criminal offence.<br>
+  From time to time this website may also include links to other websites. These links are provided for your convenience to provide further information. They do not signify that we endorse the website(s). We have no responsibility for the content of the linked website(s).
+  Your use of this website and any dispute arising out of such use of the website is subject to the laws of England, Northern Ireland, Scotland and Wales.{% endblocktrans %}</p>
+
+  <h2>{% trans "How we use cookies" %}</h2>
+  <p>{% blocktrans %}A cookie is a small file which asks permission to be placed on your computer's hard drive. Once you agree, the file is added and the cookie helps analyse web traffic or lets you know when you visit a particular site.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}Cookies allow web applications to respond to you as an individual. The web application can tailor its operations to your needs, likes and dislikes by gathering and remembering information about your preferences. A cookie in no way gives us access to your computer or any information about you, other than the data you choose to share with us.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the website.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}In this website we use cookies to:{% endblocktrans %}</p>
+
+  <ul>
+    <li>{% trans "Help us analyse how our website is used." %}</li>
+    <li>{% trans "To ensure other sites can’t “forge” requests." %}</li>
+    <li>{% trans "Remember your choices within the application, for your convenience, and where relevant remember that you are logged into the application." %}</li>
+  </ul>
+
+  <p>{% blocktrans %}Open Data Services Co-operative Limited uses <a href="http://piwik.org">Piwik</a> to analyse usage of our website (see Piwik section below). This uses cookies to identify you (anonymously) as the same user, so that we can analyse our web traffic better. E.g. it allows us to count how many users we have, instead of just total page views or analyse what pages people commonly visit together.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}If you do allow cookies to be used, Piwik uses 1st party cookies, set on the domain of this website. Cookies created by Piwik start with: {% endblocktrans %}</p>
+  <ul>
+    <li>_pk_ref</li>
+    <li>_pk_cvar</li>
+    <li>_pk_id</li>
+    <li>_pk_ses</li>
+  </ul>
+
+  <p>{% blocktrans %}See: <a href="http://piwik.org/faq/general/faq_146/">http://piwik.org/faq/general/faq_146/</a> for more information.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}The application is built using <a href="https://www.djangoproject.com/">Django</a> and we use that framework to set the following cookies:{% endblocktrans %}</p>
+   <ul>{% comment %}Translators: csrftoken, cookielaw_accepted, and sessionid are names of cookies and do not need translation {% endcomment %}
+    <li>{% trans "csrftoken - (to prevent cross site scripting attacks https://docs.djangoproject.com/en/1.8/ref/csrf/#how-it-works)" %}</li>
+    <li>{% trans "sessionid - (you will get this if you interact with the application, so that we can save the things you have done, e.g. select a language)" %}</li>
+    <li>{% trans "cookielaw_accepted - (you will get this if you choose to accept cookies to remember that choice)" %}</li>
+  </ul>
+
+  <p>{% blocktrans %}If you choose not to accept these cookies the application may not work for you.{% endblocktrans %}</p>
+
+  <h2>{% trans "Piwik Traffic Analytics" %}</h2>
+
+  <p>{% blocktrans %}Open Data Services Co-operative Limited use their own hosted version of <a href="http://piwik.org">Piwik</a> to analyse our web traffic. They do this to get an idea of how much traffic we are getting, where from and when.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Piwik will not track your visit.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}Piwik also it’s own opt out mechanism:{% endblocktrans %}</p>
+  <!-- opt out iframe - clicking this will mean people can opt out of tracking -->
+  <iframe style="border: 1; height: 150px; width: 600px;" src="http://mon.opendataservices.coop/piwik/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
+
+  <h2>{% trans "Server Logs" %}</h2>
+  <p>{% blocktrans %}Open Data Services Co-operative Limited keep server logs of traffic to, and activity on, our all of our servers. Primarily this is to help us keep our servers healthy and working by knowing how much activity is taking place on them.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}We use the ELK stack (Elasticsearch, Logstash, Kibana) to analyse Server logs. {% endblocktrans %}</p> 
+  <p>{% blocktrans %}Our server logs record information such as your IP address, the browser you are using, and your operating system. Generally, this is considered not to constitute personal information, but we recognise that when aggregated, and analysed there is a chance that this data could potentially enable identification of individuals. This is not something we do. {% endblocktrans %}</p>
+
+  <h2>{% trans "Privacy Policy" %}</h2>
+  <p>360Giving is a charity that provides support for grantmakers to publish their grants data openly, to understand their data, and to use the data to create online tools that make grantmaking more effective. It is responsible for this website and its contents.</p>
+  
+  <p>This Privacy Policy explains how we use, disclose and manage the personal information we collect from you by mail, in person, through our website and through third party websites that contain 360Giving forms.</p>
+  
+  <p>You may choose to provide 360Giving with personal information, such as your name, email address, telephone number or postal address. If you do so, we may choose to add you to our mailing list for updates on our work. You can unsubscribe from this mailing list at any point by clicking ‘unsubscribe’ or contacting us (see below).</p>
+  
+  <p>If you provide any of the above-mentioned information to us it will be:</p>
+  
+  <ul>
+    <li>Used to send you communications associated with 360Giving.</li>
+    <li>Deleted when you tell us that you would like this information removed.</li>
+  </ul>
+  
+  <p>We may use the personal information you provide us for internal purposes, such as for website administration, data analytics and compliance purposes.</p>
+  
+  <p>360Giving may share your personal information with service providers, who will be authorised to act only under our instructions or to comply with legal obligations. In addition, we may disclose information about you to comply with our legal obligations.</p>
+  
+  <p>You have the right to access, update, and correct inaccuracies in your personal information, subject to certain exceptions prescribed by law, by using the contact email shown below. You can also opt out of receiving communications from us in the same way. Please allow at least 28 days for communications to cease and for your details to be removed from our mailing lists.</p>
+  
+  <p>If you have any questions or comments about this Privacy Policy, or to update your information please email: <a href="mailto:support@threesixtygiving.org">support@threesixtygiving.org</a></p>
+  
+  <p>360Giving reserves the right to update or amend this policy at any time and without prior notice.</p>
+
+  <h2>{% trans "Links to other websites" %}</h2>
+  <p>{% blocktrans %}Our website may contain links to other websites of interest. However, once you have used these links to leave our site, you should note that we do not have any control over that other website. Therefore, we cannot be responsible for the protection and privacy of any information which you provide whilst visiting such sites and such sites are not governed by this privacy statement. You should exercise caution and look at the privacy statement applicable to the website in question.{% endblocktrans %}</p>
+
+  <h2>{% trans "Website disclaimer" %}</h2>
+  <p>{% blocktrans %}The information contained in this website is for general information purposes only. The information is provided by Open Data Services Co-operative Limited and while we endeavour to keep the information up to date and correct, we make no representations or warranties of any kind, express or implied, about the completeness, accuracy, reliability, suitability or availability with respect to the website or the information, products, services, or related graphics contained on the website for any purpose. Any reliance you place on such information is therefore strictly at your own risk.
+  In no event will we be liable for any loss or damage including without limitation, indirect or consequential loss or damage, or any loss or damage whatsoever arising from loss of data or profits arising out of, or in connection with, the use of this website.
+  Through this website you are able to link to other websites which are not under the control of Open Data Services Co-operative Limited. We have no control over the nature, content and availability of those sites. The inclusion of any links does not necessarily imply a recommendation or endorse the views expressed within them.
+  Every effort is made to keep the website up and running smoothly. However, Open Data Services Co-operative Limited takes no responsibility for, and will not be liable for, the website being temporarily unavailable due to technical issues beyond our control.{% endblocktrans %}</p>
+
+
+</div>
+
+{% endblock %}

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -50,3 +50,8 @@ def test_bad_search(dataload, server_url, browser):
     browser.find_element_by_name("text_query").send_keys(" £s:::::afdsfas")
     browser.find_element_by_class_name("large-search-icon").click()
     assert 'Search input is not valid' in browser.find_element_by_tag_name('body').text
+
+
+def test_terms(server_url, browser):
+    browser.get(server_url + '/terms')
+    assert 'Terms & conditions' in browser.find_element_by_tag_name('h1').text

--- a/grantnav/frontend/urls.py
+++ b/grantnav/frontend/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from . import views
+from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^$', views.home, name='home'),
@@ -13,4 +14,5 @@ urlpatterns = [
     url(r'^region/(.*)$', views.region, name='region'),
     url(r'^district/(.*)$', views.district, name='district'),
     url(r'^stats', views.stats, name='stats'),
+    url(r'^terms', TemplateView.as_view(template_name='terms.html'), name='terms'),
 ]


### PR DESCRIPTION
This also covers the privacy policy

Note that I have written the page to cover two organisations
I have used the privacy policy from http://www.threesixtygiving.org/privacy/
and pasted that in.
The main text comes from the CoVE terms and conditions page, but with
some re-writes and some sections removed.
A link to this page is placed in the footer with some CSS to theme it
A test is added to check that this page exists and has a h1

<!---
@huboard:{"custom_state":"","order":177.0,"milestone_order":177}
-->
