### PR TITLE
Adds a take down policy page

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -86,6 +86,12 @@ a.anchor {
     padding: 0;
 }
 
+.footer-menu li {
+  display:inline;
+  list-style-type: none;
+  margin-right: 10px;
+}
+
 .footer-info {
   margin-left: 5px;
 }
@@ -93,3 +99,4 @@ a.anchor {
 .footer-menu a {
     color: #fff;
 }
+

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -52,7 +52,13 @@
         </div>
         <div class="row">
           <div class="col-sm-12">
-            <ul id="menu-footer2" class="footer-menu"><li class="menu-item"><a href="{% url 'terms' %}">Terms and Conditions</a></li>
+            <ul id="menu-footer2" class="footer-menu">
+              <li class="menu-item">
+                <a href="{% url 'terms' %}">Terms and Conditions</a>
+              </li>
+              <li class="menu-item">
+                <a href="{% url 'take_down_policy' %}">Take Down Policy</a>
+              </li>
             </ul>
           </div>
         </div>

--- a/grantnav/frontend/templates/take_down_policy.html
+++ b/grantnav/frontend/templates/take_down_policy.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block main_content %}
+
+<div>
+  <h1>{% trans "Take Down Policy" %}</h1>
+  <p>{% blocktrans %}360Giving has a policy on what it will do if they receive a request to remove data that is published to the 360Giving standard.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}Further details can be found on our website at: <a href="http://www.threesixtygiving.org/take-down-policy/">http://www.threesixtygiving.org/take-down-policy/</a>{% endblocktrans %}</p>
+
+</div>
+
+{% endblock %}

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -35,6 +35,8 @@ def dataload():
 def test_home(dataload, server_url, browser):
     browser.get(server_url)
     assert 'GrantNav' in browser.find_element_by_tag_name('body').text
+    browser.find_element_by_link_text("Terms and Conditions")
+    browser.find_element_by_link_text("Take Down Policy")
 
 
 @pytest.mark.parametrize(('text'), [
@@ -66,3 +68,8 @@ def test_bad_search(dataload, server_url, browser):
 def test_terms(server_url, browser):
     browser.get(server_url + '/terms')
     assert 'Terms & conditions' in browser.find_element_by_tag_name('h1').text
+    
+    
+def test_take_down(server_url, browser):
+    browser.get(server_url + '/take_down_policy')
+    assert 'Take Down Policy' in browser.find_element_by_tag_name('h1').text

--- a/grantnav/frontend/urls.py
+++ b/grantnav/frontend/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
     url(r'^region/(.*)$', views.region, name='region'),
     url(r'^district/(.*)$', views.district, name='district'),
     url(r'^stats', views.stats, name='stats'),
+    url(r'^take_down_policy', TemplateView.as_view(template_name='take_down_policy.html'), name='take_down_policy'),
     url(r'^terms', TemplateView.as_view(template_name='terms.html'), name='terms'),
 ]


### PR DESCRIPTION
The 360Giving site now has a take down policy.
This adds a page that basically tells people to go there for the info
Adds a link in the footer similar to that on the 360Giving site

Also fixes up the css in those footer links to remove a list-style-type which is visible otherwise
Adds tests for those links in the footer