### PR TITLE
[#216] Replace green/red icons with up down arrows in data tables

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -90,6 +90,32 @@ a.anchor {
   white-space: normal;
 }
 
+table.dataTable.dtr-inline.collapsed > tbody > tr > td:first-child::before, table.dataTable.dtr-inline.collapsed > tbody > tr > th:first-child::before {
+    top: 8px;
+    left: 4px;
+    height: 16px;
+    width: 16px;
+    display: block;
+    position: absolute;
+    color: #000;
+    opacity: 0.5;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    box-sizing: content-box;
+    text-align: left;
+    font-family: 'Courier New', Courier, monospace;
+    text-indent: 4px;
+    line-height: 16px;
+    content: '\25bc';
+    background-color: inherit;
+}
+
+table.dataTable.dtr-inline.collapsed > tbody > tr.parent > td:first-child::before, table.dataTable.dtr-inline.collapsed > tbody > tr.parent > th:first-child::before {
+    content: '\25b2';
+    background-color: inherit;
+}
+
 .download_button {
   float:right;
 }

--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -107,12 +107,12 @@ table.dataTable.dtr-inline.collapsed > tbody > tr > td:first-child::before, tabl
     font-family: 'Courier New', Courier, monospace;
     text-indent: 4px;
     line-height: 16px;
-    content: '\25bc';
+    content: '\25b6';
     background-color: inherit;
 }
 
 table.dataTable.dtr-inline.collapsed > tbody > tr.parent > td:first-child::before, table.dataTable.dtr-inline.collapsed > tbody > tr.parent > th:first-child::before {
-    content: '\25b2';
+    content: '\25bc';
     background-color: inherit;
 }
 

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -12,10 +12,11 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         
+        {% block extra_style %} {% endblock %}
         <link rel="stylesheet" href="{% static 'cookielaw/css/cookielaw.css'%}">
         <link rel="stylesheet" href="{% static 'css/theme.css'%}">
         <link rel="stylesheet" href="{% static 'css/main.css'%}">
-        {% block extra_style %} {% endblock %}
+
 
     </head>
     <body>


### PR DESCRIPTION
Uses CSS to change the icons used in the data tables on e.g. a funders page

Re-orders where 'extra-style' is loaded in the base template so that our
main.css file gets loaded last. This may have unintended consequences, please review.

<!---
@huboard:{"order":9.160309982437144e-05,"milestone_order":218,"custom_state":""}
-->
