### PR TITLE
[#236] Swaps the order of the JSON and CSV download buttons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - "sudo service elasticsearch start"
 
 install: 
-    - "pip install -r requirements_dev.txt --use-mirrors"
+    - "pip install -r requirements_dev.txt"
 
 script:
     - "flake8 ."

--- a/grantnav/frontend/templates/district.html
+++ b/grantnav/frontend/templates/district.html
@@ -38,11 +38,11 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         Grants
-        <a class="pull-right" href="{% url 'district.csv' district %}">
-          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-        </a>
         <a class="pull-right" href="{% url 'district.json' district %}">
           <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
+        </a>
+        <a class="pull-right" href="{% url 'district.csv' district %}">
+          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
         </a>
       </div>
       <div class="panel-body">

--- a/grantnav/frontend/templates/funder.html
+++ b/grantnav/frontend/templates/funder.html
@@ -38,11 +38,11 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         Recipients
-        <a class="pull-right" href="{% url 'funder_recipients_datatables.csv' %}?funder_id={{ funder.id }}">
-          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-        </a>
         <a class="pull-right" href="{% url 'funder_recipients_datatables.json' %}?funder_id={{ funder.id }}">
           <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
+        </a>
+        <a class="pull-right" href="{% url 'funder_recipients_datatables.csv' %}?funder_id={{ funder.id }}">
+          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
         </a>
       </div>
       <div class="panel-body">

--- a/grantnav/frontend/templates/funders.html
+++ b/grantnav/frontend/templates/funders.html
@@ -11,11 +11,11 @@
   </div>
   <div class="col-xs-6">
     <h1 class="pull-right">
-      <a href="{% url 'funders_datatables.csv' %}">
-        <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-      </a>
       <a href="{% url 'funders_datatables.json' %}">
         <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
+      </a>
+      <a href="{% url 'funders_datatables.csv' %}">
+        <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
       </a>
     </h1>
   </div>

--- a/grantnav/frontend/templates/recipient.html
+++ b/grantnav/frontend/templates/recipient.html
@@ -38,12 +38,13 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         Grants
-        <a class="pull-right" href="{% url 'recipient.csv' recipient.id %}">
-          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-        </a>
         <a class="pull-right" href="{% url 'recipient.json' recipient.id %}">
           <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
         </a>
+        <a class="pull-right" href="{% url 'recipient.csv' recipient.id %}">
+          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
+        </a>
+
       </div>
       <div class="panel-body">
         <table class="table table-condensed table-bordered table-striped dt-responsive" id="grants_datatable" width="100%">

--- a/grantnav/frontend/templates/recipients.html
+++ b/grantnav/frontend/templates/recipients.html
@@ -11,11 +11,11 @@
   </div>
   <div class="col-xs-6">
     <h1 class="pull-right">
-      <a href="{% url 'funder_recipients_datatables.csv' %}">
-        <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-      </a>
       <a href="{% url 'funder_recipients_datatables.json' %}">
         <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
+      </a>
+      <a href="{% url 'funder_recipients_datatables.csv' %}">
+        <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
       </a>
     </h1>
   </div>

--- a/grantnav/frontend/templates/region.html
+++ b/grantnav/frontend/templates/region.html
@@ -38,11 +38,11 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         Grants
-        <a href="{% url 'region.csv' region %}">
-          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
-        </a>
         <a href="{% url 'region.json' region %}">
           <img src="{% static 'images/json_download_icon.png' %}" alt="Download JSON" class="download_button"/>
+        </a>
+        <a href="{% url 'region.csv' region %}">
+          <img src="{% static 'images/csv_download_icon.png' %}" alt="Download CSV" class="download_button"/>
         </a>
       </div>
       <div class="panel-body">


### PR DESCRIPTION
CSV now comes first on a rendered css view - but not int the code
because of the pull-right css class

NB - not changed on search.html to avoid conflicts