### PR TITLE
331 textchanges sf

### DIFF
--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -54,13 +54,13 @@
         <div class="row">
           <div class="col-md-4 col-sm-4">
             <img src="{% static 'images/360logo_invert.png'%}" height="80" width="196">
-            <p class="footer-info">360Giving provide support for grantmakers to publish their grants data openly, to understand their data, and to use the data to create online tools that make grantmaking more effective.</p>
+            <p class="footer-info">360Giving supports organisations to publish their grants data in an open, standardised way and helps people to understand and use the data to support decision-making and learning across the charitable giving sector.</p>
             <p class="footer-info">Find out more about <a href="http://www.threesixtygiving.org/">360Giving</a></p>
           </div>
           <div class="col-md-4 col-sm-4">
-            <p class="footer-info">GrantNav uses open data published to the 360Giving standard.</p>
+            <p class="footer-info">GrantNav uses open data published to the <a href="http://www.threesixtygiving.org/standard/">360Giving standard</a>.</p>
             <p class="footer-info">GrantNav enables people to search, filter and download across these datasets, for free.</p>
-            <p class="footer-info">Got some feedback?  Visit here or send emails to <a href="mailto:grantnav@threesixtygiving.org">grantnav@threesixtygiving.org</a></p>
+            <p class="footer-info">For feedback and questions, please email <a href="mailto:grantnav@threesixtygiving.org">grantnav@threesixtygiving.org</a></p>
           </div>
           <div class="col-md-4 col-sm-4">
             <p class="footer-info">Links</p>

--- a/grantnav/frontend/templates/datasets.html
+++ b/grantnav/frontend/templates/datasets.html
@@ -8,22 +8,21 @@
 
 <p>The data used by GrantNav is open data. GrantNav contains:</p>
 <ul>
-  <li>data published to the <a href="http://www.threesixtygiving.org/standard/">360Giving standard</a></li>
-  <li>data derived from <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> </li>
-  <li>data derived from <a href="http://data.charitycommission.gov.uk/default.aspx">Charity Commission data</a></li>
+  <li>Data published to the <a href="http://www.threesixtygiving.org/standard/">360Giving standard</a></li>
+  <li>Data derived from <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> </li>
+  <li>Data derived from <a href="http://data.charitycommission.gov.uk/default.aspx">Charity Commission data</a></li>
 </ul> 
 
-<p>Data published to the 360Giving standard is taken from an <a href="http://www.threesixtygiving.org/data/find-data/">up to date list on the 360Giving website</a>.<br>
-The <a href="/datasets/#datasets-used">360Giving Datasets Used table</a> below lists the specific datasets used in GrantNav, how they are licensed, and when they were retrieved.
+<p>Data published to the 360Giving standard is taken from an <a href="http://www.threesixtygiving.org/data/find-data/">up to date list on the 360Giving website</a>.  The <a href="/datasets/#datasets-used">360Giving Datasets Used table</a> below lists the specific datasets used in GrantNav, how they are licensed, and when they were retrieved.
 </p>
 
-<p>We use the <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> data to augment some of the location data.<br>We use the <a href="http://data.charitycommission.gov.uk/default.aspx">Charity Commission data</a> to look up charity names.<br>Both these datasets are licensed under an <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government License</a>, see <a href="#copyright">Copyright and Attribution</a> below for full details.<p>
+<p>We use the <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> data to augment some of the location data.  We use the <a href="http://data.charitycommission.gov.uk/default.aspx">Charity Commission data</a> to look up charity names.  Both these datasets are licensed under an <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government License</a>, see <a href="#copyright">Copyright and Attribution</a> below for full details.<p>
   
 
 <h2>Reporting a problem with data</h2>
-If you see a problem with data about a grant on GrantNav, please report it directly to the relevant publisher - see the "Where is this data from?" section at the bottom of a grant page for more information.
+If you see a problem any data on this site, please report it directly to the relevant organisation.  To find out how to contact them, see the "Where is this data from?" section at the bottom of each grant page.
 
-<h2 id="datasets-used">360Giving Datasets Used</h2>
+<h2 id="datasets-used">360Giving datasets used</h2>
 
 <table class="table table-condensed table-bordered table-striped dt-responsive">
 <thead>
@@ -51,14 +50,13 @@ If you see a problem with data about a grant on GrantNav, please report it direc
 
 <h2 id="reuse">Reusing GrantNav data</h2>
 
-<p>The data in GrantNav is meant to be used and reused, not least by downloading data from search results.</p>
-<p>As all of the data used in GrantNav has has been published under compatible open licenses you may reuse any of the data in, or taken from, GrantNav under the terms of the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Sharealike license (CC-BY-SA)</a>.<br>
-This means it can be reused for any purpose provided that you provide attribution, and release any derived works under the same license.
+<p>The data included in GrantNav is made openly available for anyone to access and reuse.</p>
+<p>All the data has been published under compatible open licenses. The data can be reused for any purposes under the terms of the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Sharealike license (CC-BY-SA)</a>.  This means it can be reused for any purpose provided that it is attributed, and any derived works are released under the same license.
 </p>
 <p><strong>To reuse data from GrantNav, you must:</strong></p>
 <ul>
-<li><a href="attributing-grantnav">attribute GrantNav</a>, AND</li>
-<li>provide copyright and attribution information about the original data. See <a href="#copyright">Copyright and Attribution</a> for a full list.</li>
+<li><a href="attributing-grantnav">Attribute GrantNav</a>, and</li>
+<li>Provide copyright and attribution information about the original data. See <a href="#copyright">Copyright and Attribution</a> for a full list.</li>
 </ul>
 
 <h4 id="attributing-grantnav">Attributing GrantNav</h4>
@@ -67,9 +65,9 @@ This means it can be reused for any purpose provided that you provide attributio
 <p>Contains data from <a href="">GrantNav</a> a <a href="http://www.threesixtygiving.org/">360Giving</a> application released under the terms of the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Sharealike license (CC-BY-SA)</a></p>
 </blockquote>
 
-<h2 id="copyright">Copyright and Attribution</h2>
+<h2 id="copyright">Copyright and attribution</h2>
 
-    <p>The data on this website can be used under the terms of the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Sharealike license (CC-BY-SA)</a>, see <a href="#reuse">Reusing GrantNav data</a> above for an attribution statement. The original data also have their own copyright and attribution statements:</p>
+    <p>The data on this website can be used under the terms of the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Sharealike license (CC-BY-SA)</a>, see <a href="#reuse">Reusing GrantNav data</a> above for an attribution statement. The original datasets also have their own copyright and attribution statements:</p>
 
 <ul>
 <li>

--- a/grantnav/frontend/templates/take_down_policy.html
+++ b/grantnav/frontend/templates/take_down_policy.html
@@ -4,9 +4,9 @@
 
 <div>
   <h1>{% trans "Take Down Policy" %}</h1>
-  <p>{% blocktrans %}360Giving has a policy on what it will do if they receive a request to remove data that is published to the 360Giving standard.{% endblocktrans %}</p>
+  <p>{% blocktrans %}This policy sets out what 360Giving will do if it receives a request to remove data that is published to the 360Giving standard.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}Further details can be found on our website at: <a href="http://www.threesixtygiving.org/take-down-policy/">http://www.threesixtygiving.org/take-down-policy/</a>{% endblocktrans %}</p>
+  <p>{% blocktrans %}Further details can be found on the 360Giving website at: <a href="http://www.threesixtygiving.org/take-down-policy/">http://www.threesixtygiving.org/take-down-policy/</a>{% endblocktrans %}</p>
 
 </div>
 

--- a/grantnav/frontend/templates/terms.html
+++ b/grantnav/frontend/templates/terms.html
@@ -10,7 +10,7 @@
   
   <p>{% blocktrans %}The site is operated by 360Giving.{% endblocktrans %}</p>
   
-  <p>{% blocktrans %}If you continue to browse and use this website, you are agreeing to comply with and be bound by the following terms and conditions of use, which together with our privacy policy govern 360Giving and Open Data Services Co-operative Limited's relationship with you in relation to this website. If you disagree with any part of these terms and conditions, please do not use this website.{% endblocktrans %}</p>
+  <p>{% blocktrans %}If you continue to browse and use this website, you are agreeing to comply with and be bound by the following terms and conditions of use, which together with our privacy policy govern 360Giving's relationship with you in relation to this website. If you disagree with any part of these terms and conditions, please do not use this website.{% endblocktrans %}</p>
   
   <p> The term &#8216;you&#8217; refers to the user or viewer of this website.</p>
 

--- a/grantnav/frontend/templates/terms.html
+++ b/grantnav/frontend/templates/terms.html
@@ -16,9 +16,6 @@
 
   <p>The terms &#8216;360Giving&#8217; or &#8216;us&#8217; or &#8216;we&#8217; refers to the owner of the website. 360Giving's company registration number is 9668396. Its registered charity number is 1164883. The registered address is 54 Wilton Road, London, SW1P 1DE.</p>
 
-  <p>{% blocktrans %}The term 'Open Data Services Co-operative Limited' refers to the operator of the website on behalf of 360Giving. Open Data Services Co-operative Limited's company registration number is 09506232. Their registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN.{% endblocktrans %}</p>
-  
-
   <p>{% blocktrans %}The use of this website is subject to the following terms of use:{% endblocktrans %}</p>
 
   <p>{% blocktrans %}The content of the pages of this website is for your general information and use only. It is subject to change without notice.{% endblocktrans %}</p>
@@ -46,7 +43,7 @@
     <li>{% trans "Remember your choices within the application, for your convenience, and where relevant remember that you are logged into the application." %}</li>
   </ul>
 
-  <p>{% blocktrans %}Open Data Services Co-operative Limited uses <a href="http://piwik.org">Piwik</a> to analyse usage of this website (see Piwik section below). This uses cookies to identify you (anonymously) as the same user, so that we can analyse our web traffic better. E.g. it allows us to count how many users we have, instead of just total page views or analyse what pages people commonly visit together.{% endblocktrans %}</p>
+  <p>{% blocktrans %}This site uses <a href="http://piwik.org">Piwik</a> to analyse usage of this website (see Piwik section below). This uses cookies to identify you (anonymously) as the same user, so that we can analyse our web traffic better. E.g. it allows us to count how many users we have, instead of just total page views or analyse what pages people commonly visit together.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}If you do allow cookies to be used, Piwik uses 1st party cookies, set on the domain of this website. Cookies created by Piwik start with: {% endblocktrans %}</p>
   <ul>
@@ -69,7 +66,7 @@
 
   <h2>{% trans "Piwik Traffic Analytics" %}</h2>
 
-  <p>{% blocktrans %}Open Data Services Co-operative Limited use their own hosted version of <a href="http://piwik.org">Piwik</a> to analyse traffic to this website. They do this to get an idea of how much traffic we are getting, where from and when.{% endblocktrans %}</p>
+  <p>{% blocktrans %}360Giving use their own hosted version of <a href="http://piwik.org">Piwik</a> to analyse traffic to this website. They do this to get an idea of how much traffic we are getting, where from and when.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Piwik will not track your visit.{% endblocktrans %}</p>
 
@@ -78,7 +75,7 @@
   <iframe style="border: 1; height: 150px; width: 600px;" src="http://mon.opendataservices.coop/piwik/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
 
   <h2>{% trans "Server Logs" %}</h2>
-  <p>{% blocktrans %}Open Data Services Co-operative Limited keeps server logs of traffic to, and activity on, all of its servers. This is to help keep the servers healthy and working by knowing how much activity is taking place on them.{% endblocktrans %}</p>
+  <p>{% blocktrans %}360Giving keeps server logs of traffic to, and activity on, all of its servers. This is to help keep the servers healthy and working by knowing how much activity is taking place on them.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}The ELK stack (Elasticsearch, Logstash, Kibana) is used to analyse server logs. {% endblocktrans %}</p> 
   <p>{% blocktrans %}The server logs record information such as your IP address, the browser you are using and your operating system. Generally, this is considered not to constitute personal information, but we recognise that when aggregated and analysed there is a chance that this data could potentially enable identification of individuals. This is not something we do. {% endblocktrans %}</p>

--- a/grantnav/frontend/templates/terms.html
+++ b/grantnav/frontend/templates/terms.html
@@ -3,18 +3,20 @@
 {% block main_content %}
 
 <div>
-  <h1>{% trans "Terms &amp; conditions" %}</h1>
-  <p>{% blocktrans %}This web application is free software designed to help people explore data published to the 360Giving Data Standard.{% endblocktrans %}</p>
+  <h1>{% trans "Terms and conditions" %}</h1>
+  <p>{% blocktrans %}This web application is free software designed to help people explore data published to the <a href="http://www.threesixtygiving.org/standard/">360Giving standard</a>.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}It is offered as service WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.{% endblocktrans %}</p>
+  <p>{% blocktrans %}It is offered as service without any warranty; incuding without the implied warranty of merchantability or fitness for a partictular purpose.{% endblocktrans %}</p>
   
-  <p>{% blocktrans %}The site is operated in partnership between Open Data Services Co-operative Limited and 360Giving.{% endblocktrans %}</p>
+  <p>{% blocktrans %}The site is operated by 360Giving.{% endblocktrans %}</p>
   
-  <p>{% blocktrans %}If you continue to browse and use this website, you are agreeing to comply with and be bound by the following terms and conditions of use, which together with our privacy policy govern 360Giving and Open Data Services Co-operative Limited's relationship with you in relation to this website. If you disagree with any part of these terms and conditions, please do not use our website.{% endblocktrans %}</p>
+  <p>{% blocktrans %}If you continue to browse and use this website, you are agreeing to comply with and be bound by the following terms and conditions of use, which together with our privacy policy govern 360Giving and Open Data Services Co-operative Limited's relationship with you in relation to this website. If you disagree with any part of these terms and conditions, please do not use this website.{% endblocktrans %}</p>
+  
+  <p> The term &#8216;you&#8217; refers to the user or viewer of this website.</p>
 
-  <p>The term &#8216;360Giving&#8217; or &#8216;us&#8217; or &#8216;we&#8217; refers to the owner of the website. Our company registration number is 9668396. Our registered address is The Peak, 5 Wilton Road, London, SW1P 1AP. The term &#8216;you&#8217; refers to the user or viewer of our website.</p>
+  <p>The terms &#8216;360Giving&#8217; or &#8216;us&#8217; or &#8216;we&#8217; refers to the owner of the website. 360Giving's company registration number is 9668396. Its registered charity number is 1164883. The registered address is 54 Wilton Road, London, SW1P 1DE.</p>
 
-  <p>{% blocktrans %}The term 'Open Data Services Co-operative Limited' refers to the operator of the website on behalf of 360Giving. Open Data Services Co-operative Limited's company registration number is 09506232. Their registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN. There is more company information on the <a href="https://opencorporates.com/companies/gb/09506232">Open Data Services Co-operative Limited page at Open Corporates</a>.{% endblocktrans %}</p>
+  <p>{% blocktrans %}The term 'Open Data Services Co-operative Limited' refers to the operator of the website on behalf of 360Giving. Open Data Services Co-operative Limited's company registration number is 09506232. Their registered address is 32 Church Road, Hove, East Sussex, England, BN3 2FN.{% endblocktrans %}</p>
   
 
   <p>{% blocktrans %}The use of this website is subject to the following terms of use:{% endblocktrans %}</p>
@@ -34,17 +36,17 @@
 
   <p>{% blocktrans %}Cookies allow web applications to respond to you as an individual. The web application can tailor its operations to your needs, likes and dislikes by gathering and remembering information about your preferences. A cookie in no way gives us access to your computer or any information about you, other than the data you choose to share with us.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the website.{% endblocktrans %}</p>
+  <p>{% blocktrans %}You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the website.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}In this website we use cookies to:{% endblocktrans %}</p>
+  <p>{% blocktrans %}In this website, cookies are used to:{% endblocktrans %}</p>
 
   <ul>
-    <li>{% trans "Help us analyse how our website is used." %}</li>
-    <li>{% trans "To ensure other sites can’t “forge” requests." %}</li>
+    <li>{% trans "Help analyse how our website is used." %}</li>
+    <li>{% trans "Ensure other sites can’t “forge” requests." %}</li>
     <li>{% trans "Remember your choices within the application, for your convenience, and where relevant remember that you are logged into the application." %}</li>
   </ul>
 
-  <p>{% blocktrans %}Open Data Services Co-operative Limited uses <a href="http://piwik.org">Piwik</a> to analyse usage of our website (see Piwik section below). This uses cookies to identify you (anonymously) as the same user, so that we can analyse our web traffic better. E.g. it allows us to count how many users we have, instead of just total page views or analyse what pages people commonly visit together.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Open Data Services Co-operative Limited uses <a href="http://piwik.org">Piwik</a> to analyse usage of this website (see Piwik section below). This uses cookies to identify you (anonymously) as the same user, so that we can analyse our web traffic better. E.g. it allows us to count how many users we have, instead of just total page views or analyse what pages people commonly visit together.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}If you do allow cookies to be used, Piwik uses 1st party cookies, set on the domain of this website. Cookies created by Piwik start with: {% endblocktrans %}</p>
   <ul>
@@ -56,35 +58,35 @@
 
   <p>{% blocktrans %}See: <a href="http://piwik.org/faq/general/faq_146/">http://piwik.org/faq/general/faq_146/</a> for more information.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}The application is built using <a href="https://www.djangoproject.com/">Django</a> and we use that framework to set the following cookies:{% endblocktrans %}</p>
+  <p>{% blocktrans %}This website is built using <a href="https://www.djangoproject.com/">Django</a> and we use that framework to set the following cookies:{% endblocktrans %}</p>
    <ul>{% comment %}Translators: csrftoken, cookielaw_accepted, and sessionid are names of cookies and do not need translation {% endcomment %}
-    <li>{% trans "csrftoken - (to prevent cross site scripting attacks https://docs.djangoproject.com/en/1.8/ref/csrf/#how-it-works)" %}</li>
-    <li>{% trans "sessionid - (you will get this if you interact with the application, so that we can save the things you have done, e.g. select a language)" %}</li>
+    <li>{% trans "csrftoken - (to prevent cross site scripting attacks)" %}</li>
+    <li>{% trans "sessionid - (so that we can save the things you have done, e.g. select a language)" %}</li>
     <li>{% trans "cookielaw_accepted - (you will get this if you choose to accept cookies to remember that choice)" %}</li>
   </ul>
 
-  <p>{% blocktrans %}If you choose not to accept these cookies the application may not work for you.{% endblocktrans %}</p>
+  <p>{% blocktrans %}If you choose not to accept these cookies then this website may not work for you.{% endblocktrans %}</p>
 
   <h2>{% trans "Piwik Traffic Analytics" %}</h2>
 
-  <p>{% blocktrans %}Open Data Services Co-operative Limited use their own hosted version of <a href="http://piwik.org">Piwik</a> to analyse our web traffic. They do this to get an idea of how much traffic we are getting, where from and when.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Open Data Services Co-operative Limited use their own hosted version of <a href="http://piwik.org">Piwik</a> to analyse traffic to this website. They do this to get an idea of how much traffic we are getting, where from and when.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Piwik will not track your visit.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}Piwik also it’s own opt out mechanism:{% endblocktrans %}</p>
+  <p>{% blocktrans %}Piwik also has its own opt out mechanism:{% endblocktrans %}</p>
   <!-- opt out iframe - clicking this will mean people can opt out of tracking -->
   <iframe style="border: 1; height: 150px; width: 600px;" src="http://mon.opendataservices.coop/piwik/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
 
   <h2>{% trans "Server Logs" %}</h2>
-  <p>{% blocktrans %}Open Data Services Co-operative Limited keep server logs of traffic to, and activity on, our all of our servers. Primarily this is to help us keep our servers healthy and working by knowing how much activity is taking place on them.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Open Data Services Co-operative Limited keeps server logs of traffic to, and activity on, all of its servers. This is to help keep the servers healthy and working by knowing how much activity is taking place on them.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}We use the ELK stack (Elasticsearch, Logstash, Kibana) to analyse Server logs. {% endblocktrans %}</p> 
-  <p>{% blocktrans %}Our server logs record information such as your IP address, the browser you are using, and your operating system. Generally, this is considered not to constitute personal information, but we recognise that when aggregated, and analysed there is a chance that this data could potentially enable identification of individuals. This is not something we do. {% endblocktrans %}</p>
+  <p>{% blocktrans %}The ELK stack (Elasticsearch, Logstash, Kibana) is used to analyse server logs. {% endblocktrans %}</p> 
+  <p>{% blocktrans %}The server logs record information such as your IP address, the browser you are using and your operating system. Generally, this is considered not to constitute personal information, but we recognise that when aggregated and analysed there is a chance that this data could potentially enable identification of individuals. This is not something we do. {% endblocktrans %}</p>
 
   <h2>{% trans "Privacy Policy" %}</h2>
-  <p>360Giving is a charity that provides support for grantmakers to publish their grants data openly, to understand their data, and to use the data to create online tools that make grantmaking more effective. It is responsible for this website and its contents.</p>
+  <p>360Giving is a charity that supports organisations to publish their grants data in an open, standardised way and helps people to understand and use the data, in order to support decision-making and learning across the charitable giving sector.  We are responsible for this website.</p>
   
-  <p>This Privacy Policy explains how we use, disclose and manage the personal information we collect from you by mail, in person, through our website and through third party websites that contain 360Giving forms.</p>
+  <p>This Privacy Policy explains how 360Giving uses, discloses and manages the personal information we collect from you by mail, in person, through our website and through third party websites that contain 360Giving forms.</p>
   
   <p>You may choose to provide 360Giving with personal information, such as your name, email address, telephone number or postal address. If you do so, we may choose to add you to our mailing list for updates on our work. You can unsubscribe from this mailing list at any point by clicking ‘unsubscribe’ or contacting us (see below).</p>
   
@@ -99,20 +101,20 @@
   
   <p>360Giving may share your personal information with service providers, who will be authorised to act only under our instructions or to comply with legal obligations. In addition, we may disclose information about you to comply with our legal obligations.</p>
   
-  <p>You have the right to access, update, and correct inaccuracies in your personal information, subject to certain exceptions prescribed by law, by using the contact email shown below. You can also opt out of receiving communications from us in the same way. Please allow at least 28 days for communications to cease and for your details to be removed from our mailing lists.</p>
+  <p>You have the right to access, update and correct inaccuracies in your personal information, subject to certain exceptions prescribed by law, by using the contact email shown below. You can also opt out of receiving communications from us in the same way. Please allow at least 28 days for communications to cease and for your details to be removed from our mailing lists.</p>
   
   <p>If you have any questions or comments about this Privacy Policy, or to update your information please email: <a href="mailto:support@threesixtygiving.org">support@threesixtygiving.org</a></p>
   
   <p>360Giving reserves the right to update or amend this policy at any time and without prior notice.</p>
 
   <h2>{% trans "Links to other websites" %}</h2>
-  <p>{% blocktrans %}Our website may contain links to other websites of interest. However, once you have used these links to leave our site, you should note that we do not have any control over that other website. Therefore, we cannot be responsible for the protection and privacy of any information which you provide whilst visiting such sites and such sites are not governed by this privacy statement. You should exercise caution and look at the privacy statement applicable to the website in question.{% endblocktrans %}</p>
+  <p>{% blocktrans %}This website contains links to other websites. If you use these links to leave this site, you should note that we do not have any control over that other website. Therefore, we cannot be responsible for the protection and privacy of any information which you provide whilst visiting such sites and such sites are not governed by this privacy statement. You should exercise caution and look at the privacy statement applicable to the website in question.{% endblocktrans %}</p>
 
   <h2>{% trans "Website disclaimer" %}</h2>
-  <p>{% blocktrans %}The information contained in this website is for general information purposes only. The information is provided by Open Data Services Co-operative Limited and while we endeavour to keep the information up to date and correct, we make no representations or warranties of any kind, express or implied, about the completeness, accuracy, reliability, suitability or availability with respect to the website or the information, products, services, or related graphics contained on the website for any purpose. Any reliance you place on such information is therefore strictly at your own risk.
+  <p>{% blocktrans %}The information contained in this website is for general information purposes only. The information is provided by 360Giving and by the organisations publishing their data to the 360Giving standard. While we endeavour to keep the information up to date and correct, we make no representations or warranties of any kind, express or implied, about the completeness, accuracy, reliability, suitability or availability with respect to the website or the information, productss, services or related graphics contained on the website for any purpose. Any reliance you place on such information is therefore strictly at your own risk.
   In no event will we be liable for any loss or damage including without limitation, indirect or consequential loss or damage, or any loss or damage whatsoever arising from loss of data or profits arising out of, or in connection with, the use of this website.
-  Through this website you are able to link to other websites which are not under the control of Open Data Services Co-operative Limited. We have no control over the nature, content and availability of those sites. The inclusion of any links does not necessarily imply a recommendation or endorse the views expressed within them.
-  Every effort is made to keep the website up and running smoothly. However, Open Data Services Co-operative Limited takes no responsibility for, and will not be liable for, the website being temporarily unavailable due to technical issues beyond our control.{% endblocktrans %}</p>
+  Through this website you are able to link to other websites. We have no control over the nature, content and availability of those sites. The inclusion of any links does not necessarily imply a recommendation or endorse the views expressed within them.
+  Every effort is made to keep the website up and running smoothly. However, 360Giving takes no responsibility for, and will not be liable for, the website being temporarily unavailable due to technical issues beyond our control.{% endblocktrans %}</p>
 
 
 </div>


### PR DESCRIPTION
These are the text changes requested by 360Giving.  They centre on:

- tense / language / consistency of terms
- some grammatical issues - eg: the Oxford comma in {apples, pears, and oranges]
- Removing Open Data Services from the terms (as these were copied from our website)
- Changes to the footer (base.html) that adjust the language used to describe 360/GN