### PR TITLE
NI geographies - lookups & postcode

### DIFF
--- a/LICENCE.rst
+++ b/LICENCE.rst
@@ -34,7 +34,14 @@ Contains OS data © Crown copyright and database right 2016
 
 Contains Royal Mail data © Royal Mail copyright and Database right 2016
 
-Contains National Statistics data © Crown copyright and database right 2016  
+Contains National Statistics data © Crown copyright and database right 2016
+
+Northern Ireland Ward to Council Area Lookup
+---------------
+
+GrantNav uses `Northern Ireland Ward to Council Area Lookup <https://ons.maps.arcgis.com/home/item.html?id=cce0999ed17f4fbd9f2f5480997405c5>`_ data which is distributed under an `Open Government Licence (v3) <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>`_
+
+Contains National Statistics data © Crown copyright and database right 2015
 
 Charity Commission Data
 -----------------------

--- a/dataload/WD15_LGD15_NI_LU.csv
+++ b/dataload/WD15_LGD15_NI_LU.csv
@@ -1,0 +1,463 @@
+WD15CD,WD15NM,LGD15CD,LGD15NM
+N08000101,Abbey,N09000001,Antrim and Newtownabbey
+N08000102,Aldergrove,N09000001,Antrim and Newtownabbey
+N08000103,Antrim Centre,N09000001,Antrim and Newtownabbey
+N08000104,Ballyclare East,N09000001,Antrim and Newtownabbey
+N08000105,Ballyclare West,N09000001,Antrim and Newtownabbey
+N08000106,Ballyduff,N09000001,Antrim and Newtownabbey
+N08000107,Ballyhenry,N09000001,Antrim and Newtownabbey
+N08000108,Ballynure,N09000001,Antrim and Newtownabbey
+N08000109,Ballyrobert,N09000001,Antrim and Newtownabbey
+N08000110,Burnthill,N09000001,Antrim and Newtownabbey
+N08000111,Carnmoney,N09000001,Antrim and Newtownabbey
+N08000112,Carnmoney Hill,N09000001,Antrim and Newtownabbey
+N08000113,Clady,N09000001,Antrim and Newtownabbey
+N08000114,Collinbridge,N09000001,Antrim and Newtownabbey
+N08000115,Cranfield,N09000001,Antrim and Newtownabbey
+N08000116,Crumlin,N09000001,Antrim and Newtownabbey
+N08000117,Doagh,N09000001,Antrim and Newtownabbey
+N08000118,Fairview,N09000001,Antrim and Newtownabbey
+N08000119,Fountain Hill,N09000001,Antrim and Newtownabbey
+N08000120,Glebe,N09000001,Antrim and Newtownabbey
+N08000121,Glengormley,N09000001,Antrim and Newtownabbey
+N08000122,Greystone,N09000001,Antrim and Newtownabbey
+N08000123,Hightown,N09000001,Antrim and Newtownabbey
+N08000124,Jordanstown,N09000001,Antrim and Newtownabbey
+N08000125,Mallusk,N09000001,Antrim and Newtownabbey
+N08000126,Monkstown,N09000001,Antrim and Newtownabbey
+N08000127,Mossley,N09000001,Antrim and Newtownabbey
+N08000128,O'Neill,N09000001,Antrim and Newtownabbey
+N08000129,Parkgate,N09000001,Antrim and Newtownabbey
+N08000130,Randalstown,N09000001,Antrim and Newtownabbey
+N08000131,Rathcoole,N09000001,Antrim and Newtownabbey
+N08000132,Rostulla,N09000001,Antrim and Newtownabbey
+N08000133,Shilvodan,N09000001,Antrim and Newtownabbey
+N08000134,Springfarm,N09000001,Antrim and Newtownabbey
+N08000135,Steeple,N09000001,Antrim and Newtownabbey
+N08000136,Stiles,N09000001,Antrim and Newtownabbey
+N08000137,Templepatrick,N09000001,Antrim and Newtownabbey
+N08000138,Toome,N09000001,Antrim and Newtownabbey
+N08000139,Valley,N09000001,Antrim and Newtownabbey
+N08000140,Whitehouse,N09000001,Antrim and Newtownabbey
+N08000201,Aghagallon,N09000002,"Armagh, Banbridge and Craigavon"
+N08000202,Ballybay,N09000002,"Armagh, Banbridge and Craigavon"
+N08000203,Banbridge East,N09000002,"Armagh, Banbridge and Craigavon"
+N08000204,Banbridge North,N09000002,"Armagh, Banbridge and Craigavon"
+N08000205,Banbridge South,N09000002,"Armagh, Banbridge and Craigavon"
+N08000206,Banbridge West,N09000002,"Armagh, Banbridge and Craigavon"
+N08000207,Blackwatertown,N09000002,"Armagh, Banbridge and Craigavon"
+N08000208,Bleary,N09000002,"Armagh, Banbridge and Craigavon"
+N08000209,Brownlow,N09000002,"Armagh, Banbridge and Craigavon"
+N08000210,Cathedral,N09000002,"Armagh, Banbridge and Craigavon"
+N08000211,Corcrain,N09000002,"Armagh, Banbridge and Craigavon"
+N08000212,Craigavon Centre,N09000002,"Armagh, Banbridge and Craigavon"
+N08000213,Demesne,N09000002,"Armagh, Banbridge and Craigavon"
+N08000214,Derrytrasna,N09000002,"Armagh, Banbridge and Craigavon"
+N08000215,Donaghcloney,N09000002,"Armagh, Banbridge and Craigavon"
+N08000216,Dromore,N09000002,"Armagh, Banbridge and Craigavon"
+N08000217,Gilford,N09000002,"Armagh, Banbridge and Craigavon"
+N08000218,Gransha,N09000002,"Armagh, Banbridge and Craigavon"
+N08000219,Hamiltonsbawn,N09000002,"Armagh, Banbridge and Craigavon"
+N08000220,Keady,N09000002,"Armagh, Banbridge and Craigavon"
+N08000221,Kernan,N09000002,"Armagh, Banbridge and Craigavon"
+N08000222,Killycomain,N09000002,"Armagh, Banbridge and Craigavon"
+N08000223,Knocknashane,N09000002,"Armagh, Banbridge and Craigavon"
+N08000224,Lough Road,N09000002,"Armagh, Banbridge and Craigavon"
+N08000225,Loughbrickland,N09000002,"Armagh, Banbridge and Craigavon"
+N08000226,Loughgall,N09000002,"Armagh, Banbridge and Craigavon"
+N08000227,Magheralin,N09000002,"Armagh, Banbridge and Craigavon"
+N08000228,Mahon,N09000002,"Armagh, Banbridge and Craigavon"
+N08000229,Markethill,N09000002,"Armagh, Banbridge and Craigavon"
+N08000230,Mourneview,N09000002,"Armagh, Banbridge and Craigavon"
+N08000231,Navan,N09000002,"Armagh, Banbridge and Craigavon"
+N08000232,Parklake,N09000002,"Armagh, Banbridge and Craigavon"
+N08000233,Quilly,N09000002,"Armagh, Banbridge and Craigavon"
+N08000234,Rathfriland,N09000002,"Armagh, Banbridge and Craigavon"
+N08000235,Richhill,N09000002,"Armagh, Banbridge and Craigavon"
+N08000236,Seagahan,N09000002,"Armagh, Banbridge and Craigavon"
+N08000237,Shankill,N09000002,"Armagh, Banbridge and Craigavon"
+N08000238,Tandragee,N09000002,"Armagh, Banbridge and Craigavon"
+N08000239,The Birches,N09000002,"Armagh, Banbridge and Craigavon"
+N08000240,The Mall,N09000002,"Armagh, Banbridge and Craigavon"
+N08000241,Waringstown,N09000002,"Armagh, Banbridge and Craigavon"
+N08000301,Andersonstown,N09000003,Belfast
+N08000302,Ardoyne,N09000003,Belfast
+N08000303,Ballygomartin,N09000003,Belfast
+N08000304,Ballymacarrett,N09000003,Belfast
+N08000305,Ballymurphy,N09000003,Belfast
+N08000306,Ballysillan,N09000003,Belfast
+N08000307,Beechmount,N09000003,Belfast
+N08000308,Beersbridge,N09000003,Belfast
+N08000309,Bellevue,N09000003,Belfast
+N08000310,Belmont,N09000003,Belfast
+N08000311,Belvoir,N09000003,Belfast
+N08000312,Blackstaff,N09000003,Belfast
+N08000313,Bloomfield,N09000003,Belfast
+N08000314,Cavehill,N09000003,Belfast
+N08000315,Central,N09000003,Belfast
+N08000316,Chichester Park,N09000003,Belfast
+N08000317,Cliftonville,N09000003,Belfast
+N08000318,Clonard,N09000003,Belfast
+N08000319,Collin Glen,N09000003,Belfast
+N08000320,Connswater,N09000003,Belfast
+N08000321,Cregagh,N09000003,Belfast
+N08000322,Duncairn,N09000003,Belfast
+N08000323,Dunmurry,N09000003,Belfast
+N08000324,Falls,N09000003,Belfast
+N08000325,Falls Park,N09000003,Belfast
+N08000326,Finaghy,N09000003,Belfast
+N08000327,Forth River,N09000003,Belfast
+N08000328,Fortwilliam,N09000003,Belfast
+N08000329,Garnerville,N09000003,Belfast
+N08000330,Gilnahirk,N09000003,Belfast
+N08000331,Hillfoot,N09000003,Belfast
+N08000332,Innisfayle,N09000003,Belfast
+N08000333,Knock,N09000003,Belfast
+N08000334,Ladybrook,N09000003,Belfast
+N08000335,Lagmore,N09000003,Belfast
+N08000336,Legoniel,N09000003,Belfast
+N08000337,Malone,N09000003,Belfast
+N08000338,Merok,N09000003,Belfast
+N08000339,Musgrave,N09000003,Belfast
+N08000340,New Lodge,N09000003,Belfast
+N08000341,Orangefield,N09000003,Belfast
+N08000342,Ormeau,N09000003,Belfast
+N08000343,Poleglass,N09000003,Belfast
+N08000344,Ravenhill,N09000003,Belfast
+N08000345,Rosetta,N09000003,Belfast
+N08000346,Sandown,N09000003,Belfast
+N08000347,Shandon,N09000003,Belfast
+N08000348,Shankill,N09000003,Belfast
+N08000349,Shaw's Road,N09000003,Belfast
+N08000350,Stewartstown,N09000003,Belfast
+N08000351,Stormont,N09000003,Belfast
+N08000352,Stranmillis,N09000003,Belfast
+N08000353,Sydenham,N09000003,Belfast
+N08000354,Turf Lodge,N09000003,Belfast
+N08000355,Twinbrook,N09000003,Belfast
+N08000356,Upper Malone,N09000003,Belfast
+N08000357,Water Works,N09000003,Belfast
+N08000358,Windsor,N09000003,Belfast
+N08000359,Woodstock,N09000003,Belfast
+N08000360,Woodvale,N09000003,Belfast
+N08000401,Aghadowey,N09000004,Causeway Coast and Glens
+N08000402,Altahullion,N09000004,Causeway Coast and Glens
+N08000403,Atlantic,N09000004,Causeway Coast and Glens
+N08000404,Ballycastle,N09000004,Causeway Coast and Glens
+N08000405,Ballykelly,N09000004,Causeway Coast and Glens
+N08000406,Ballymoney East,N09000004,Causeway Coast and Glens
+N08000407,Ballymoney North,N09000004,Causeway Coast and Glens
+N08000408,Ballymoney South,N09000004,Causeway Coast and Glens
+N08000409,Castlerock,N09000004,Causeway Coast and Glens
+N08000410,Churchland,N09000004,Causeway Coast and Glens
+N08000411,Clogh Mills,N09000004,Causeway Coast and Glens
+N08000412,Coolessan,N09000004,Causeway Coast and Glens
+N08000413,Dervock,N09000004,Causeway Coast and Glens
+N08000414,Drumsurn,N09000004,Causeway Coast and Glens
+N08000415,Dundooan,N09000004,Causeway Coast and Glens
+N08000416,Dungiven,N09000004,Causeway Coast and Glens
+N08000417,Dunloy,N09000004,Causeway Coast and Glens
+N08000418,Feeny,N09000004,Causeway Coast and Glens
+N08000419,Garvagh,N09000004,Causeway Coast and Glens
+N08000420,Giant's Causeway,N09000004,Causeway Coast and Glens
+N08000421,Greysteel,N09000004,Causeway Coast and Glens
+N08000422,Greystone,N09000004,Causeway Coast and Glens
+N08000423,Hopefield,N09000004,Causeway Coast and Glens
+N08000424,Kilrea,N09000004,Causeway Coast and Glens
+N08000425,Kinbane,N09000004,Causeway Coast and Glens
+N08000426,Loughguile and Stranocum,N09000004,Causeway Coast and Glens
+N08000427,Lurigethan,N09000004,Causeway Coast and Glens
+N08000428,Macosquin,N09000004,Causeway Coast and Glens
+N08000429,Magilligan,N09000004,Causeway Coast and Glens
+N08000430,Mountsandel,N09000004,Causeway Coast and Glens
+N08000431,Portrush and Dunluce,N09000004,Causeway Coast and Glens
+N08000432,Portstewart,N09000004,Causeway Coast and Glens
+N08000433,Quarry,N09000004,Causeway Coast and Glens
+N08000434,Rasharkin,N09000004,Causeway Coast and Glens
+N08000435,Roeside,N09000004,Causeway Coast and Glens
+N08000436,Route,N09000004,Causeway Coast and Glens
+N08000437,Torr Head and Rathlin,N09000004,Causeway Coast and Glens
+N08000438,University,N09000004,Causeway Coast and Glens
+N08000439,Waterside,N09000004,Causeway Coast and Glens
+N08000440,Windy Hall,N09000004,Causeway Coast and Glens
+N08000501,Artigarvan,N09000005,Derry and Strabane
+N08000502,Ballycolman,N09000005,Derry and Strabane
+N08000503,Ballymagroarty,N09000005,Derry and Strabane
+N08000504,Brandywell,N09000005,Derry and Strabane
+N08000505,Carn Hill,N09000005,Derry and Strabane
+N08000506,Castlederg,N09000005,Derry and Strabane
+N08000507,Caw,N09000005,Derry and Strabane
+N08000508,City Walls,N09000005,Derry and Strabane
+N08000509,Claudy,N09000005,Derry and Strabane
+N08000510,Clondermot,N09000005,Derry and Strabane
+N08000511,Creggan,N09000005,Derry and Strabane
+N08000512,Creggan South,N09000005,Derry and Strabane
+N08000513,Culmore,N09000005,Derry and Strabane
+N08000514,Drumahoe,N09000005,Derry and Strabane
+N08000515,Dunnamanagh,N09000005,Derry and Strabane
+N08000516,Ebrington,N09000005,Derry and Strabane
+N08000517,Eglinton,N09000005,Derry and Strabane
+N08000518,Enagh,N09000005,Derry and Strabane
+N08000519,Finn,N09000005,Derry and Strabane
+N08000520,Foyle Springs,N09000005,Derry and Strabane
+N08000521,Galliagh,N09000005,Derry and Strabane
+N08000522,Glenderg,N09000005,Derry and Strabane
+N08000523,Glenelly Valley,N09000005,Derry and Strabane
+N08000524,Kilfennan,N09000005,Derry and Strabane
+N08000525,Lisnagelvin,N09000005,Derry and Strabane
+N08000526,Madam's Bank,N09000005,Derry and Strabane
+N08000527,New Buildings,N09000005,Derry and Strabane
+N08000528,Newtownstewart,N09000005,Derry and Strabane
+N08000529,Northland,N09000005,Derry and Strabane
+N08000530,Park,N09000005,Derry and Strabane
+N08000531,Shantallow,N09000005,Derry and Strabane
+N08000532,Shantallow East,N09000005,Derry and Strabane
+N08000533,Sheriff's Mountain,N09000005,Derry and Strabane
+N08000534,Sion Mills,N09000005,Derry and Strabane
+N08000535,Skeoge,N09000005,Derry and Strabane
+N08000536,Slievekirk,N09000005,Derry and Strabane
+N08000537,Springtown,N09000005,Derry and Strabane
+N08000538,Strabane North,N09000005,Derry and Strabane
+N08000539,Strabane West,N09000005,Derry and Strabane
+N08000540,Victoria,N09000005,Derry and Strabane
+N08000601,Ballinamallard,N09000006,Fermanagh and Omagh
+N08000602,Belcoo and Garrison,N09000006,Fermanagh and Omagh
+N08000603,Belleek and Boa,N09000006,Fermanagh and Omagh
+N08000604,Beragh,N09000006,Fermanagh and Omagh
+N08000605,"Boho, Cleenish and Letterbreen",N09000006,Fermanagh and Omagh
+N08000606,Brookeborough,N09000006,Fermanagh and Omagh
+N08000607,Camowen,N09000006,Fermanagh and Omagh
+N08000608,Castlecoole,N09000006,Fermanagh and Omagh
+N08000609,Coolnagard,N09000006,Fermanagh and Omagh
+N08000610,Dergmoney,N09000006,Fermanagh and Omagh
+N08000611,Derrygonnelly,N09000006,Fermanagh and Omagh
+N08000612,Derrylin,N09000006,Fermanagh and Omagh
+N08000613,Donagh,N09000006,Fermanagh and Omagh
+N08000614,Dromore,N09000006,Fermanagh and Omagh
+N08000615,Drumnakilly,N09000006,Fermanagh and Omagh
+N08000616,Drumquin,N09000006,Fermanagh and Omagh
+N08000617,Ederney and Kesh,N09000006,Fermanagh and Omagh
+N08000618,Erne,N09000006,Fermanagh and Omagh
+N08000619,Fairy Water,N09000006,Fermanagh and Omagh
+N08000620,Fintona,N09000006,Fermanagh and Omagh
+N08000621,Florence Court and Kinawley,N09000006,Fermanagh and Omagh
+N08000622,Gortin,N09000006,Fermanagh and Omagh
+N08000623,Gortrush,N09000006,Fermanagh and Omagh
+N08000624,Irvinestown,N09000006,Fermanagh and Omagh
+N08000625,Killyclogher,N09000006,Fermanagh and Omagh
+N08000626,Lisbellaw,N09000006,Fermanagh and Omagh
+N08000627,Lisnarrick,N09000006,Fermanagh and Omagh
+N08000628,Lisnaskea,N09000006,Fermanagh and Omagh
+N08000629,Maguiresbridge,N09000006,Fermanagh and Omagh
+N08000630,Newtownbutler,N09000006,Fermanagh and Omagh
+N08000631,Newtownsaville,N09000006,Fermanagh and Omagh
+N08000632,Owenkillew,N09000006,Fermanagh and Omagh
+N08000633,Portora,N09000006,Fermanagh and Omagh
+N08000634,Rosslea,N09000006,Fermanagh and Omagh
+N08000635,Rossorry,N09000006,Fermanagh and Omagh
+N08000636,Sixmilecross,N09000006,Fermanagh and Omagh
+N08000637,Strule,N09000006,Fermanagh and Omagh
+N08000638,Tempo,N09000006,Fermanagh and Omagh
+N08000639,Termon,N09000006,Fermanagh and Omagh
+N08000640,Trillick,N09000006,Fermanagh and Omagh
+N08000701,Ballinderry,N09000007,Lisburn and Castlereagh
+N08000702,Ballyhanwood,N09000007,Lisburn and Castlereagh
+N08000703,Ballymacash,N09000007,Lisburn and Castlereagh
+N08000704,Ballymacbrennan,N09000007,Lisburn and Castlereagh
+N08000705,Ballymacoss,N09000007,Lisburn and Castlereagh
+N08000706,Beechill,N09000007,Lisburn and Castlereagh
+N08000707,Blaris,N09000007,Lisburn and Castlereagh
+N08000708,Cairnshill,N09000007,Lisburn and Castlereagh
+N08000709,Carrowreagh,N09000007,Lisburn and Castlereagh
+N08000710,Carryduff East,N09000007,Lisburn and Castlereagh
+N08000711,Carryduff West,N09000007,Lisburn and Castlereagh
+N08000712,Derryaghy,N09000007,Lisburn and Castlereagh
+N08000713,Dromara,N09000007,Lisburn and Castlereagh
+N08000714,Drumbo,N09000007,Lisburn and Castlereagh
+N08000715,Dundonald,N09000007,Lisburn and Castlereagh
+N08000716,Enler,N09000007,Lisburn and Castlereagh
+N08000717,Galwally,N09000007,Lisburn and Castlereagh
+N08000718,Glenavy,N09000007,Lisburn and Castlereagh
+N08000719,Graham's Bridge,N09000007,Lisburn and Castlereagh
+N08000720,Harmony Hill,N09000007,Lisburn and Castlereagh
+N08000721,Hilden,N09000007,Lisburn and Castlereagh
+N08000722,Hillhall,N09000007,Lisburn and Castlereagh
+N08000723,Hillsborough,N09000007,Lisburn and Castlereagh
+N08000724,Knockbracken,N09000007,Lisburn and Castlereagh
+N08000725,Knockmore,N09000007,Lisburn and Castlereagh
+N08000726,Lagan,N09000007,Lisburn and Castlereagh
+N08000727,Lagan Valley,N09000007,Lisburn and Castlereagh
+N08000728,Lambeg,N09000007,Lisburn and Castlereagh
+N08000729,Lisnagarvey,N09000007,Lisburn and Castlereagh
+N08000730,Maghaberry,N09000007,Lisburn and Castlereagh
+N08000731,Magheralave,N09000007,Lisburn and Castlereagh
+N08000732,Maze,N09000007,Lisburn and Castlereagh
+N08000733,Moira,N09000007,Lisburn and Castlereagh
+N08000734,Moneyreagh,N09000007,Lisburn and Castlereagh
+N08000735,Newtownbreda,N09000007,Lisburn and Castlereagh
+N08000736,Old Warren,N09000007,Lisburn and Castlereagh
+N08000737,Ravernet,N09000007,Lisburn and Castlereagh
+N08000738,Stonyford,N09000007,Lisburn and Castlereagh
+N08000739,Wallace Park,N09000007,Lisburn and Castlereagh
+N08000740,White Mountain,N09000007,Lisburn and Castlereagh
+N08000801,Academy,N09000008,Mid and East Antrim
+N08000802,Ahoghill,N09000008,Mid and East Antrim
+N08000803,Ardeevin,N09000008,Mid and East Antrim
+N08000804,Ballee and Harryville,N09000008,Mid and East Antrim
+N08000805,Ballycarry and Glynn,N09000008,Mid and East Antrim
+N08000806,Ballykeel,N09000008,Mid and East Antrim
+N08000807,Boneybefore,N09000008,Mid and East Antrim
+N08000808,Braidwater,N09000008,Mid and East Antrim
+N08000809,Broughshane,N09000008,Mid and East Antrim
+N08000810,Burleigh Hill,N09000008,Mid and East Antrim
+N08000811,Cairncastle,N09000008,Mid and East Antrim
+N08000812,Carnlough and Glenarm,N09000008,Mid and East Antrim
+N08000813,Castle,N09000008,Mid and East Antrim
+N08000814,Castle Demesne,N09000008,Mid and East Antrim
+N08000815,Craigyhill,N09000008,Mid and East Antrim
+N08000816,Cullybackey,N09000008,Mid and East Antrim
+N08000817,Curran and Inver,N09000008,Mid and East Antrim
+N08000818,Fair Green,N09000008,Mid and East Antrim
+N08000819,Galgorm,N09000008,Mid and East Antrim
+N08000820,Gardenmore,N09000008,Mid and East Antrim
+N08000821,Glenravel,N09000008,Mid and East Antrim
+N08000822,Glenwhirry,N09000008,Mid and East Antrim
+N08000823,Gortalee,N09000008,Mid and East Antrim
+N08000824,Grange,N09000008,Mid and East Antrim
+N08000825,Greenisland,N09000008,Mid and East Antrim
+N08000826,Islandmagee,N09000008,Mid and East Antrim
+N08000827,Kells,N09000008,Mid and East Antrim
+N08000828,Kilroot,N09000008,Mid and East Antrim
+N08000829,Kilwaughter,N09000008,Mid and East Antrim
+N08000830,Kirkinriola,N09000008,Mid and East Antrim
+N08000831,Love Lane,N09000008,Mid and East Antrim
+N08000832,Maine,N09000008,Mid and East Antrim
+N08000833,Park,N09000008,Mid and East Antrim
+N08000834,Portglenone,N09000008,Mid and East Antrim
+N08000835,Slemish,N09000008,Mid and East Antrim
+N08000836,Sunnylands,N09000008,Mid and East Antrim
+N08000837,The Maidens,N09000008,Mid and East Antrim
+N08000838,Victoria,N09000008,Mid and East Antrim
+N08000839,Whitehead South,N09000008,Mid and East Antrim
+N08000840,Woodburn,N09000008,Mid and East Antrim
+N08000901,Ardboe,N09000009,Mid Ulster
+N08000902,Augher and Clogher,N09000009,Mid Ulster
+N08000903,Aughnacloy,N09000009,Mid Ulster
+N08000904,Ballygawley,N09000009,Mid Ulster
+N08000905,Ballymaguigan,N09000009,Mid Ulster
+N08000906,Ballysaggart,N09000009,Mid Ulster
+N08000907,Bellaghy,N09000009,Mid Ulster
+N08000908,Caledon,N09000009,Mid Ulster
+N08000909,Castlecaulfield,N09000009,Mid Ulster
+N08000910,Castledawson,N09000009,Mid Ulster
+N08000911,Coagh,N09000009,Mid Ulster
+N08000912,Coalisland North,N09000009,Mid Ulster
+N08000913,Coalisland South,N09000009,Mid Ulster
+N08000914,Cookstown East,N09000009,Mid Ulster
+N08000915,Cookstown South,N09000009,Mid Ulster
+N08000916,Cookstown West,N09000009,Mid Ulster
+N08000917,Coolshinny,N09000009,Mid Ulster
+N08000918,Donaghmore,N09000009,Mid Ulster
+N08000919,Draperstown,N09000009,Mid Ulster
+N08000920,Fivemiletown,N09000009,Mid Ulster
+N08000921,Glebe,N09000009,Mid Ulster
+N08000922,Killyman,N09000009,Mid Ulster
+N08000923,Killymeal,N09000009,Mid Ulster
+N08000924,Lissan,N09000009,Mid Ulster
+N08000925,Loughry,N09000009,Mid Ulster
+N08000926,Lower Glenshane,N09000009,Mid Ulster
+N08000927,Maghera,N09000009,Mid Ulster
+N08000928,Moy,N09000009,Mid Ulster
+N08000929,Moygashel,N09000009,Mid Ulster
+N08000930,Mullaghmore,N09000009,Mid Ulster
+N08000931,Oaklands,N09000009,Mid Ulster
+N08000932,Pomeroy,N09000009,Mid Ulster
+N08000933,Stewartstown,N09000009,Mid Ulster
+N08000934,Swatragh,N09000009,Mid Ulster
+N08000935,Tamlaght O'Crilly,N09000009,Mid Ulster
+N08000936,The Loup,N09000009,Mid Ulster
+N08000937,Tobermore,N09000009,Mid Ulster
+N08000938,Town Parks East,N09000009,Mid Ulster
+N08000939,Valley,N09000009,Mid Ulster
+N08000940,Washing Bay,N09000009,Mid Ulster
+N08001001,Abbey,N09000010,"Newry, Mourne and Down"
+N08001002,Annalong,N09000010,"Newry, Mourne and Down"
+N08001003,Ballybot,N09000010,"Newry, Mourne and Down"
+N08001004,Ballydugan,N09000010,"Newry, Mourne and Down"
+N08001005,Ballynahinch,N09000010,"Newry, Mourne and Down"
+N08001006,Ballyward,N09000010,"Newry, Mourne and Down"
+N08001007,Bessbrook,N09000010,"Newry, Mourne and Down"
+N08001008,Binnian,N09000010,"Newry, Mourne and Down"
+N08001009,Burren,N09000010,"Newry, Mourne and Down"
+N08001010,Camlough,N09000010,"Newry, Mourne and Down"
+N08001011,Castlewellan,N09000010,"Newry, Mourne and Down"
+N08001012,Cathedral,N09000010,"Newry, Mourne and Down"
+N08001013,Crossgar and Killyleagh,N09000010,"Newry, Mourne and Down"
+N08001014,Crossmaglen,N09000010,"Newry, Mourne and Down"
+N08001015,Damolly,N09000010,"Newry, Mourne and Down"
+N08001016,Derryboy,N09000010,"Newry, Mourne and Down"
+N08001017,Derryleckagh,N09000010,"Newry, Mourne and Down"
+N08001018,Donard,N09000010,"Newry, Mourne and Down"
+N08001019,Drumalane,N09000010,"Newry, Mourne and Down"
+N08001020,Drumaness,N09000010,"Newry, Mourne and Down"
+N08001021,Dundrum,N09000010,"Newry, Mourne and Down"
+N08001022,Fathom,N09000010,"Newry, Mourne and Down"
+N08001023,Forkhill,N09000010,"Newry, Mourne and Down"
+N08001024,Hilltown,N09000010,"Newry, Mourne and Down"
+N08001025,Kilkeel,N09000010,"Newry, Mourne and Down"
+N08001026,Kilmore,N09000010,"Newry, Mourne and Down"
+N08001027,Knocknashinna,N09000010,"Newry, Mourne and Down"
+N08001028,Lecale,N09000010,"Newry, Mourne and Down"
+N08001029,Lisnacree,N09000010,"Newry, Mourne and Down"
+N08001030,Mayobridge,N09000010,"Newry, Mourne and Down"
+N08001031,Mullaghbane,N09000010,"Newry, Mourne and Down"
+N08001032,Murlough,N09000010,"Newry, Mourne and Down"
+N08001033,Newtownhamilton,N09000010,"Newry, Mourne and Down"
+N08001034,Quoile,N09000010,"Newry, Mourne and Down"
+N08001035,Rostrevor,N09000010,"Newry, Mourne and Down"
+N08001036,Saintfield,N09000010,"Newry, Mourne and Down"
+N08001037,St. Patrick's,N09000010,"Newry, Mourne and Down"
+N08001038,Strangford,N09000010,"Newry, Mourne and Down"
+N08001039,Tollymore,N09000010,"Newry, Mourne and Down"
+N08001040,Warrenpoint,N09000010,"Newry, Mourne and Down"
+N08001041,Whitecross,N09000010,"Newry, Mourne and Down"
+N08001101,Ballycrochan,N09000011,North Down and Ards
+N08001102,Ballygowan,N09000011,North Down and Ards
+N08001103,Ballygrainey,N09000011,North Down and Ards
+N08001104,Ballyholme,N09000011,North Down and Ards
+N08001105,Ballymagee,N09000011,North Down and Ards
+N08001106,Ballywalter,N09000011,North Down and Ards
+N08001107,Bloomfield,N09000011,North Down and Ards
+N08001108,Broadway,N09000011,North Down and Ards
+N08001109,Bryansburn,N09000011,North Down and Ards
+N08001110,Carrowdore,N09000011,North Down and Ards
+N08001111,Castle,N09000011,North Down and Ards
+N08001112,Clandeboye,N09000011,North Down and Ards
+N08001113,Comber North,N09000011,North Down and Ards
+N08001114,Comber South,N09000011,North Down and Ards
+N08001115,Comber West,N09000011,North Down and Ards
+N08001116,Conway Square,N09000011,North Down and Ards
+N08001117,Cronstown,N09000011,North Down and Ards
+N08001118,Cultra,N09000011,North Down and Ards
+N08001119,Donaghadee,N09000011,North Down and Ards
+N08001120,Glen,N09000011,North Down and Ards
+N08001121,Gregstown,N09000011,North Down and Ards
+N08001122,Groomsport,N09000011,North Down and Ards
+N08001123,Harbour,N09000011,North Down and Ards
+N08001124,Helen's Bay,N09000011,North Down and Ards
+N08001125,Holywood,N09000011,North Down and Ards
+N08001126,Kilcooley,N09000011,North Down and Ards
+N08001127,Killinchy,N09000011,North Down and Ards
+N08001128,Kircubbin,N09000011,North Down and Ards
+N08001129,Loughries,N09000011,North Down and Ards
+N08001130,Loughview,N09000011,North Down and Ards
+N08001131,Movilla,N09000011,North Down and Ards
+N08001132,Portaferry,N09000011,North Down and Ards
+N08001133,Portavogie,N09000011,North Down and Ards
+N08001134,Rathgael,N09000011,North Down and Ards
+N08001135,Rathmore,N09000011,North Down and Ards
+N08001136,Scrabo,N09000011,North Down and Ards
+N08001137,Silverbirch,N09000011,North Down and Ards
+N08001138,Silverstream,N09000011,North Down and Ards
+N08001139,Warren,N09000011,North Down and Ards
+N08001140,West Winds,N09000011,North Down and Ards

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -260,6 +260,10 @@ def update_doc_with_region(grant):
     except (KeyError, IndexError):
         post_code = ''
 
+    ## If there is a 'BT' postcode we can safely assume this is in NI
+    if post_code and post_code.startswith("BT"):
+        grant['recipientRegionName'] = "Northern Ireland"
+
     # test postcode first
     area = postcode_to_area.get(str(post_code).replace(' ', '').upper())
     if area:
@@ -348,6 +352,23 @@ def get_area_mappings():
             }
             ward_code_to_area[ward_code] = {
                 'district_name': district_name, 'area_name': area_name, 'ward_name': ward_name
+            }
+
+    ## Northern Ireland codes and names not included in Code-Point, but uses a separate source
+    with open(os.path.join(current_dir, 'WD15_LGD15_NI_LU.csv')) as ni_lookup:
+        ni_lookup_csv = csv.DictReader(ni_lookup)
+
+        for row in ni_lookup_csv:
+            district_code = row['LGD15CD']
+            district_name = row['LGD15NM']
+            ward_code = row['WD15CD']
+            ward_name = row['WD15NM']
+
+            district_code_to_area[district_code] = {
+                'district_name': district_name, 'area_name': 'Northern Ireland'
+            }
+            ward_code_to_area[ward_code] = {
+                'district_name': district_name, 'area_name': 'Northern Ireland', 'ward_name': ward_name
             }
 
 if __name__ == '__main__':

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -260,7 +260,7 @@ def update_doc_with_region(grant):
     except (KeyError, IndexError):
         post_code = ''
 
-    ## If there is a 'BT' postcode we can safely assume this is in NI
+    # If there is a 'BT' postcode we can safely assume this is in NI
     if post_code and post_code.startswith("BT"):
         grant['recipientRegionName'] = "Northern Ireland"
 
@@ -354,7 +354,7 @@ def get_area_mappings():
                 'district_name': district_name, 'area_name': area_name, 'ward_name': ward_name
             }
 
-    ## Northern Ireland codes and names not included in Code-Point, but uses a separate source
+    # Northern Ireland codes and names not included in Code-Point, but uses a separate source
     with open(os.path.join(current_dir, 'WD15_LGD15_NI_LU.csv')) as ni_lookup:
         ni_lookup_csv = csv.DictReader(ni_lookup)
 

--- a/grantnav/csv_layout.py
+++ b/grantnav/csv_layout.py
@@ -65,7 +65,7 @@ grant_csv_titles = [
     "Recipient Ward",
     "Retrieved for use in GrantNav",
     "License (see note)",
-    "Note: this file also contains OS data © Crown copyright and database right 2016, Royal Mail data © Royal Mail copyright and Database right 2016, National Statistics data © Crown copyright and database right 2016, see http://grantnav.threesixtygiving.org/datasets/ for more information.",
+    "Note: this file also contains OS data © Crown copyright and database right 2016, Royal Mail data © Royal Mail copyright and Database right 2016, National Statistics data © Crown copyright and database right 2015 & 2016, see http://grantnav.threesixtygiving.org/datasets/ for more information.",
 ]
 
 grant_csv_paths = [

--- a/grantnav/frontend/templates/datasets.html
+++ b/grantnav/frontend/templates/datasets.html
@@ -11,7 +11,8 @@
   <li>Data published to the <a href="http://www.threesixtygiving.org/standard/">360Giving Standard</a></li>
   <li>Data derived from <a href="https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html">Code-Point Open</a> </li>
   <li>Data derived from <a href="http://data.charitycommission.gov.uk/default.aspx">Charity Commission data</a></li>
-</ul> 
+  <li>Data derived from <a href="https://ons.maps.arcgis.com/home/item.html?id=cce0999ed17f4fbd9f2f5480997405c5">Northern Ireland Ward to Council Area Lookup</a></li>
+</ul>
 
 <p>Data published to the 360Giving Standard is taken from an <a href="http://www.threesixtygiving.org/data/find-data/">up to date list on the 360Giving website</a>.  The <a href="/datasets/#datasets-used">360Giving Datasets Used table</a> below lists the specific datasets used in GrantNav, how they are licensed, and when they were retrieved.
 </p>
@@ -108,7 +109,7 @@ Contains OS data &copy; Crown copyright and database right 2016
 Contains Royal Mail data &copy; Royal Mail copyright and Database right 2016
 </li>
 <li>
-Contains National Statistics data &copy; Crown copyright and database right 2016
+Contains National Statistics data &copy; Crown copyright and database right 2015 &amp; 2016
 </li>
 </ul>
 <li>

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -89,7 +89,7 @@ def test_footer_links(provenance_dataload, server_url, browser, link_text):
 @pytest.mark.parametrize(('text'), [
     ('Contains OS data © Crown copyright and database right 2016'),
     ('Contains Royal Mail data © Royal Mail copyright and Database right 2016'),
-    ('Contains National Statistics data © Crown copyright and database right 2016')
+    ('Contains National Statistics data © Crown copyright and database right 2015 & 2016')
     ])
 def test_code_point_credit(provenance_dataload, server_url, browser, text):
     browser.get(server_url)


### PR DESCRIPTION
At the moment, because GN relies on Code Point open for both postcode and ward/district/area lookups, NI geocodes and names are missing. I've added the relevant NI lookup csv, and modified the data import to add these codes and names, meaning any grant data with an geocode in NI will have the additional fields added.

Also, if  a postcode starts with 'BT' we can safely assume this is in Northern Ireland (a simple fact, there's no licensing issues in this case).