### PR TITLE
New Page: Help with Using GrantNav

### DIFF
--- a/grantnav/frontend/templates/about.html
+++ b/grantnav/frontend/templates/about.html
@@ -13,7 +13,7 @@
 
 <p>{% blocktrans %}GrantNav has been developed to make it easier to find out which organisations have funded which sectors or regions, making it easier to map out the resources that are available and how this may have changed over time. This will help visitors to quickly obtain an overview of other organisations working in the same areas.{% endblocktrans %}</p> 
 
-<p>{% blocktrans %}See here for tips about how to do advanced searches: <a href="http://grantnav.threesixtygiving.org/advanced_search">http://grantnav.threesixtygiving.org/advanced_search</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}See here for help with searching and downloading, including advanced searches: <a href="http://grantnav.threesixtygiving.org/help">http://grantnav.threesixtygiving.org/help</a>.{% endblocktrans %}</p>
 
 <p>{% blocktrans %}For further details about the data used in GrantNav and the tool itself please see the links in the footer below.{% endblocktrans %}</p>
 

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -75,6 +75,9 @@
                 <a href="{% url 'recipients' %}">Recipients</a>
               </li>
               <li class="menu-item">
+                <a href="{% url 'help' %}">Help with Using Grantnav</a>
+              </li>
+              <li class="menu-item">
                 <a href="{% url 'terms' %}">Terms and Conditions</a>
               </li>
               <li class="menu-item">

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -93,9 +93,6 @@
                 <a href="{% url 'datasets' %}#copyright">Copyright</a>
               </li>
               <li class="menu-item">
-                <a href="{% url 'advanced_search' %}">Advanced Search</a>
-              </li>
-              <li class="menu-item">
                 <a href="{% url 'developers' %}">Developers</a>
               </li>
             </ul>

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -75,7 +75,7 @@
                 <a href="{% url 'recipients' %}">Recipients</a>
               </li>
               <li class="menu-item">
-                <a href="{% url 'help' %}">Help with Using Grantnav</a>
+                <a href="{% url 'help' %}">Help with Using GrantNav</a>
               </li>
               <li class="menu-item">
                 <a href="{% url 'terms' %}">Terms and Conditions</a>

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -252,7 +252,7 @@
   <ul>
     <li>{% blocktrans %}Search words and phrases limited to a specific field, for example:{% endblocktrans %}
       <ul>
-        <li>{% blocktrans %}<code>title:gardens</code> will search the "title" field for the word "gardens"){% endblocktrans %}</li>
+        <li>{% blocktrans %}<code>title:gardens</code> will search the "title" field for the word "gardens"{% endblocktrans %}</li>
         <li>{% blocktrans %}<code>recipientOrganization.postalCode:NW1</code> will search the for recipients within the "NW1" postcode district (where the field is populated){% endblocktrans %}</li>
         <li>{% blocktrans %}<code>fundingOrganisation.name:"London Councils"</code> will search the "Funding Organisation:Name" field for "London Councils"{% endblocktrans %}</li>
       </ul>

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -3,7 +3,7 @@
 {% block main_content %}
 
 <div>
-  <h1>{% trans "Help with Using Grantnav" %}</h1>
+  <h1>{% trans "Help with Using GrantNav" %}</h1>
 
   <ul>
     <li><a href="#search_box">{% trans "How does the GrantNav search box work?" %}</a></li>

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -10,15 +10,15 @@
     <li><a href="#filters">{% trans "How do the GrantNav filters work?" %}</a></li>
     <li><a href="#additional_data">{% trans "Additional data and GrantNav" %}</a></li>
     <ul>
-      <li><a href="#location_data">{% trans "GrantNav and Location Data" %}</a></li>
-      <li><a href="#charity_names">{% trans "GrantNav and Charity Names" %}</a></li>
+      <li><a href="#location_data">{% trans "GrantNav and location data" %}</a></li>
+      <li><a href="#charity_names">{% trans "GrantNav and charity names" %}</a></li>
     </ul>
     <li><a href="#export_files">{% trans "What is covered in the GrantNav export files?" %}</a></li>
     <ul>
       <li><a href="#export_search">{% trans "Exporting from a search" %}</a></li>
       <li><a href="#export_funders_recipients">{% trans "Exporting from the funders and recipient pages" %}</a></li>
     </ul>
-    <li><a href="#advanced_search">{% trans "Advanced Search" %}</a></li>
+    <li><a href="#advanced_search">{% trans "Advanced search" %}</a></li>
     <ul>
       <li><a href="#words_phrases">{% trans "Words and phrases" %}</a></li>
       <li><a href="#fields">{% trans "Fields" %}</a></li>
@@ -49,7 +49,7 @@
             <td>{% trans "Only Locations" %}</td>
             <td>
               <p>{% trans "Searches the ward, district and region location of the recipient organisation, of any grant record which features this geographical information." %}</p>
-              <p>{% trans "See: GrantNav & location data." %}</p>
+              <p>{% blocktrans %}See also: <a href="#location_data">GrantNav and location data</a>{% endblocktrans %}</p>
             </td>
           </tr>
           <tr>
@@ -61,7 +61,7 @@
     </div>
   </div>
 
-  <p>{% blocktrans %}See the <a href="/advanced_search/">Advanced Search</a> page for additional ways to search the data held in GrantNav.{% endblocktrans %}</p>
+  <p>{% blocktrans %}See <a href="#advanced_search">Advanced search</a> for additional ways to search the data held in GrantNav.{% endblocktrans %}</p>
 
   <h2 id="filters">{% trans "How do the GrantNav filters work?" %}</h2>
 
@@ -91,12 +91,12 @@
           <tr>
             <td>{% trans "Recipient Region" %}</td>
             <td>{% trans "This filter is derived from 360Giving data by GrantNav" %}</td>
-            <td>{% trans "See: GrantNav & location data" %}</td>
+            <td>{% blocktrans %}See also: <a href="#location_data">GrantNav and location data</a>{% endblocktrans %}</a></td>
           </tr>
           <tr>
             <td>{% trans "Recipient District" %}</td>
             <td>{% trans "This filter is derived from 360Giving data by GrantNav" %}</td>
-            <td>{% trans "See: GrantNav & location data" %}</td>
+            <td>{% blocktrans %}See also: <a href="#location_data">GrantNav and location data</a>{% endblocktrans %}</a></td>
           </tr>
           <tr>
             <td>{% trans "Funding Organisations" %}</td>
@@ -106,7 +106,7 @@
           <tr>
             <td>{% trans "Recipient Organisations" %}</td>
             <td>{% trans "Recipient Org:Name" %}</td>
-            <td>{% trans "See also: GrantNav & Charity Names" %}</td>
+            <td>{% blocktrans %}See also: <a href="#charity_names">GrantNav and charity names</a>{% endblocktrans %}</a></td>
           </tr>
         </tbody>
       </table>
@@ -117,29 +117,29 @@
   <p>{% blocktrans %}GrantNav uses <a href="/datasets/">grants data</a> that is being published to the <a href="http://standard.threesixtygiving.org/en/latest/">360Giving Standard</a>. It is updated on a monthly basis. When the data is imported, we undertake
     two processes that mean we can provide additional data.{% endblocktrans %}</p>
 
-  <h3 id="location_data">{% trans "GrantNav and Location Data" %}</h3>
+  <h3 id="location_data">{% trans "GrantNav and location data" %}</h3>
   <p>{% blocktrans %}When we import this data, we look at the Location information associated with the Recipient Organisation. This data can vary across publishers.{% endblocktrans %}</p>
 
-  <h4>{% trans "When a Recipient Org:Postcode is provided" %}</h4>
+  <h4>{% trans "When a Recipient Org:Postal Code is provided" %}</h4>
   <p>{% blocktrans %}We use the postcode to add Ward, District and Region <a href="/datasets/">codes</a> to the data. This is used in the relevant filters in GrantNav, and also Ward, District and Region names are included in the download files.{% endblocktrans %}</p>
 
-  <h4>{% trans "When a Recipient Org:Postcode is missing" %}</h4>
+  <h4>{% trans "When a Recipient Org:Postal Code is missing" %}</h4>
   <p>{% blocktrans %}If other types of administrative geography are included in the data (such as District or Ward codes) then we attempt to match it to relevant areas. Again, these are used in the filters and the names and codes are included in the download files.{% endblocktrans %}</p>
 
-  <h3 id="charity_names">{% trans "GrantNav and Charity Names" %}</h3>
-  <p>{% blocktrans %}It’s useful for people to see multiple grants associated with a single organisation together in GrantNav. To do this, we rely on publishers including the relevant company, charity or other registration number in the Recipient Org: Identifier
+  <h3 id="charity_names">{% trans "GrantNav and charity names" %}</h3>
+  <p>{% blocktrans %}It’s useful for people to see multiple grants associated with a single organisation together in GrantNav. To do this, we rely on publishers including the relevant company, charity or other registration number in the Recipient Org:Identifier
     field.{% endblocktrans %}</p>
 
   <p>{% blocktrans %}When we import data into GrantNav, we aim to match these identifiers, in order to provide pages that bring together grants from different publishers, even if they spell the recipient names differently.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}When we undertook research to do this, we found that quite often registered charities were given different names by various publishers. Even if the Recipient Org: Identifier reference were the exact same, the name given was often different,
+  <p>{% blocktrans %}When we undertook research to do this, we found that quite often registered charities were given different names by various publishers. Even if the Recipient Org:Identifier reference were the exact same, the name given was often different,
     e.g. “Salford Lads Club” vs “Salford Lads & Girls Club”.{% endblocktrans %}</p>
 
-  <p>{% blocktrans %}In order to help users, we therefore utilise the data available from the Charity Commission for England and Wales. We look for the official name on this register. With this, we populate the Recipient Org: Name field, which in turn is
+  <p>{% blocktrans %}In order to help users, we therefore utilise the data available from the Charity Commission for England and Wales. We look for the official name on this register. With this, we populate the Recipient Org:Name field, which in turn is
     used in the relevant filter on GrantNav. However, we also maintain the original name from the publisher, and use that in the grant page and freetext search.{% endblocktrans %}</p>
 
   <h2 id="export_files">{% trans "What is covered in the GrantNav export files?" %}</h2>
-  <p>{% blocktrans %}Data can be exported from GrantNav searches, and from views of funders and recipients, in either CSV or JSON formats. You can also <a href="/developers/">download the whole data set</a> using in GrantNav.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Data can be exported from GrantNav searches, and from views of funders and recipients, in either CSV or JSON formats. You can also <a href="/developers/">download the whole data set</a> used in GrantNav.{% endblocktrans %}</p>
 
   <h3 id="export_search">{% trans "Exporting from a search" %}</h3>
   <p>{% blocktrans %}When you export data from a GrantNav search the data provided uses the same field names as the <a href="http://standard.threesixtygiving.org/en/latest/">360Giving Standard</a>. This is provided in a single file - in the case of the CSV
@@ -165,15 +165,15 @@
         </tr>
         <tr>
           <td>{% trans "Recipient Region" %}</td>
-          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+          <td>{% blocktrans %}This is the name of the geographic area, added by GrantNav (see <a href="#location_data">GrantNav and location data</a> for explanation).{% endblocktrans %}</td>
         </tr>
         <tr>
           <td>{% trans "Recipient District" %}</td>
-          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+          <td>{% blocktrans %}This is the name of the geographic area, added by GrantNav (see <a href="#location_data">GrantNav and location data</a> for explanation).{% endblocktrans %}</td>
         </tr>
         <tr>
           <td>{% trans "Recipient Ward" %}</td>
-          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+          <td>{% blocktrans %}This is the name of the geographic area, added by GrantNav (see <a href="#location_data">GrantNav and location data</a> for explanation).{% endblocktrans %}</td>
         </tr>
         <tr>
           <td>{% trans "Retrieved for use in GrantNav" %}</td>
@@ -230,7 +230,7 @@
     </div>
   </div>
 
-  <h2 id="advanced_search">{% trans "Advanced Search" %}</h2>
+  <h2 id="advanced_search">{% trans "Advanced search" %}</h2>
 
   <p>{% blocktrans %}In addition to the freetext search, there are many ways you can search the data on this site.{% endblocktrans %}</p>
   <p>{% blocktrans %}Search for:{% endblocktrans %}</p>

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -3,7 +3,7 @@
 {% block main_content %}
 
 <div>
-  <h1>{% trans "Using Grantnav" %}</h1>
+  <h1>{% trans "Help with Using Grantnav" %}</h1>
 
   <ul>
     <li><a href="#search_box">{% trans "How does the GrantNav search box work?" %}</a></li>

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -1,0 +1,305 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block main_content %}
+
+<div>
+  <h1>{% trans "Using Grantnav" %}</h1>
+
+  <ul>
+    <li><a href="#search_box">{% trans "How does the GrantNav search box work?" %}</a></li>
+    <li><a href="#filters">{% trans "How do the GrantNav filters work?" %}</a></li>
+    <li><a href="#additional_data">{% trans "Additional data and GrantNav" %}</a></li>
+    <ul>
+      <li><a href="#location_data">{% trans "GrantNav and Location Data" %}</a></li>
+      <li><a href="#charity_names">{% trans "GrantNav and Charity Names" %}</a></li>
+    </ul>
+    <li><a href="#export_files">{% trans "What is covered in the GrantNav export files?" %}</a></li>
+    <ul>
+      <li><a href="#export_search">{% trans "Exporting from a search" %}</a></li>
+      <li><a href="#export_funders_recipients">{% trans "Exporting from the funders and recipient pages" %}</a></li>
+    </ul>
+    <li><a href="#advanced_search">{% trans "Advanced Search" %}</a></li>
+    <ul>
+      <li><a href="#words_phrases">{% trans "Words and phrases" %}</a></li>
+      <li><a href="#fields">{% trans "Fields" %}</a></li>
+      <li><a href="#ranges">{% trans "Ranges" %}</a></li>
+      <li><a href="#wildcards">{% trans "Wildcards" %}</a></li>
+      <li><a href="#fuzziness">{% trans "Fuzziness" %}</a></li>
+    </ul>
+  </ul>
+
+  <h2 id="search_box">{% trans "How does the GrantNav search box work?" %}</h2>
+  <p>{% blocktrans %}GrantNav provides a freetext search box which allows you to explore the data. There are three search patterns to choose from and these work in the following ways:{% endblocktrans %}</p>
+
+  <div class="row bottom-space">
+    <div class="col-xs-12">
+      <table class="table table-condensed table-bordered table-striped dt-responsive" width="100%">
+        <thead>
+          <tr>
+            <th>{% trans "Search" %}</th>
+            <th>{% trans "Coverage" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{% trans "Search All" %}</td>
+            <td>{% trans "Searches across all fields - covering text and numbers." %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Only Locations" %}</td>
+            <td>
+              <p>{% trans "Searches the ward, district and region location of the recipient organisation, of any grant record which features this geographical information." %}</p>
+              <p>{% trans "See: GrantNav & location data." %}</p>
+            </td>
+          </tr>
+          <tr>
+            <td>{% trans "Only Recipients" %}</td>
+            <td>{% trans "Searches the name of the recipient organisation only." %}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <p>{% blocktrans %}See the <a href="/advanced_search/">Advanced Search</a> page for additional ways to search the data held in GrantNav.{% endblocktrans %}</p>
+
+  <h2 id="filters">{% trans "How do the GrantNav filters work?" %}</h2>
+
+  <p>{% blocktrans %}GrantNav has filters which appear on the left hand side of the search results. These work in relation to certain fields in the 360Giving Standard in the following ways:{% endblocktrans %}</p>
+
+  <div class="row bottom-space">
+    <div class="col-xs-12">
+      <table class="table table-condensed table-bordered table-striped dt-responsive" width="100%">
+        <thead>
+          <tr>
+            <th>{% trans "GrantNav filter" %}</th>
+            <th>{% trans "360Giving Standard field" %}</th>
+            <th>{% trans "Notes" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{% trans "Amount Awarded" %}</td>
+            <td>{% trans "Amount Awarded" %}</td>
+            <td>{% trans "Values are banded into the relevant categories." %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Award Year" %}</td>
+            <td>{% trans "The year (YYYY) component of date from Award Date field" %}</td>
+            <td>{% trans "This is calendar year, not fiscal/financial year" %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Recipient Region" %}</td>
+            <td>{% trans "This filter is derived from 360Giving data by GrantNav" %}</td>
+            <td>{% trans "See: GrantNav & location data" %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Recipient District" %}</td>
+            <td>{% trans "This filter is derived from 360Giving data by GrantNav" %}</td>
+            <td>{% trans "See: GrantNav & location data" %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Funding Organisations" %}</td>
+            <td>{% trans "Funding Org:Name" %}</td>
+            <td>{% trans "Values are taken from the data and will change if the funder name changes." %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Recipient Organisations" %}</td>
+            <td>{% trans "Recipient Org:Name" %}</td>
+            <td>{% trans "See also: GrantNav & Charity Names" %}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <h2 id="additional_data">{% trans "Additional data and GrantNav" %}</h2>
+  <p>{% blocktrans %}GrantNav uses <a href="/datasets/">grants data</a> that is being published to the <a href="http://standard.threesixtygiving.org/en/latest/">360Giving Standard</a>. It is updated on a monthly basis. When the data is imported, we undertake
+    two processes that mean we can provide additional data.{% endblocktrans %}</p>
+
+  <h3 id="location_data">{% trans "GrantNav and Location Data" %}</h3>
+  <p>{% blocktrans %}When we import this data, we look at the Location information associated with the Recipient Organisation. This data can vary across publishers.{% endblocktrans %}</p>
+
+  <h4>{% trans "When a Recipient Org:Postcode is provided" %}</h4>
+  <p>{% blocktrans %}We use the postcode to add Ward, District and Region <a href="/datasets/">codes</a> to the data. This is used in the relevant filters in GrantNav, and also Ward, District and Region names are included in the download files.{% endblocktrans %}</p>
+
+  <h4>{% trans "When a Recipient Org:Postcode is missing" %}</h4>
+  <p>{% blocktrans %}If other types of administrative geography are included in the data (such as District or Ward codes) then we attempt to match it to relevant areas. Again, these are used in the filters and the names and codes are included in the download files.{% endblocktrans %}</p>
+
+  <h3 id="charity_names">{% trans "GrantNav and Charity Names" %}</h3>
+  <p>{% blocktrans %}It’s useful for people to see multiple grants associated with a single organisation together in GrantNav. To do this, we rely on publishers including the relevant company, charity or other registration number in the Recipient Org: Identifier
+    field.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}When we import data into GrantNav, we aim to match these identifiers, in order to provide pages that bring together grants from different publishers, even if they spell the recipient names differently.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}When we undertook research to do this, we found that quite often registered charities were given different names by various publishers. Even if the Recipient Org: Identifier reference were the exact same, the name given was often different,
+    e.g. “Salford Lads Club” vs “Salford Lads & Girls Club”.{% endblocktrans %}</p>
+
+  <p>{% blocktrans %}In order to help users, we therefore utilise the data available from the Charity Commission for England and Wales. We look for the official name on this register. With this, we populate the Recipient Org: Name field, which in turn is
+    used in the relevant filter on GrantNav. However, we also maintain the original name from the publisher, and use that in the grant page and freetext search.{% endblocktrans %}</p>
+
+  <h2 id="export_files">{% trans "What is covered in the GrantNav export files?" %}</h2>
+  <p>{% blocktrans %}Data can be exported from GrantNav searches, and from views of funders and recipients, in either CSV or JSON formats. You can also <a href="/developers/">download the whole data set</a> using in GrantNav.{% endblocktrans %}</p>
+
+  <h3 id="export_search">{% trans "Exporting from a search" %}</h3>
+  <p>{% blocktrans %}When you export data from a GrantNav search the data provided uses the same field names as the <a href="http://standard.threesixtygiving.org/en/latest/">360Giving Standard</a>. This is provided in a single file - in the case of the CSV
+    file there will be multiple columns for fields that may have more than one value for some grants, such as geographic terms. Please note that not all fields in the 360Giving Standard are included in the GrantNav export files.{% endblocktrans %}
+  </p>
+
+  <p>{% blocktrans %}The following fields are not in the 360Giving Standard and are added to the export data by GrantNav:{% endblocktrans %}</p>
+
+  <div class="row bottom-space">
+    <div class="col-xs-12">
+      <table class="table table-condensed table-bordered table-striped dt-responsive" width="100%">
+        <tr>
+          <th>{% trans "Field" %}</th>
+          <th>{% trans "Description" %}</th>
+        </tr>
+        <tr>
+          <td>{% trans "Data Source" %}</td>
+          <td>{% trans "This is the URL (web link) for the data file containing this grant record." %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Publisher:Name" %}</td>
+          <td>{% trans "This is the name of the organisation publishing the data file. This data is held centrally by 360Giving." %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Recipient Region" %}</td>
+          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Recipient District" %}</td>
+          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Recipient Ward" %}</td>
+          <td>{% trans "This is the name of the geographic area, added by GrantNav (see above for explanation)." %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Retrieved for use in GrantNav" %}</td>
+          <td>{% trans "This is the date and time the data was accessed for use in GrantNav" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "License (see note below)" %}</td>
+          <td>{% trans "The URL (web link) to the specific licence under which the data file containing this grant record was published." %}</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+  <h3 id="export_funders_recipients">{% trans "Exporting from the funders and recipients pages" %}</h3>
+  <p>{% blocktrans %}Data downloaded from the <a href="/funders/">funders</a> and <a href="/recipients/">recipients</a> pages are different from the search results and grants view downloads as they contain only the details seen on screen, plus an extra column
+    with the funder or recipient identifiers.{% endblocktrans %}</p>
+
+  <div class="row bottom-space">
+    <div class="col-xs-12">
+      <table class="table table-condensed table-bordered table-striped dt-responsive" width="100%">
+        <tr>
+          <th>{% trans "Field" %}</th>
+          <th>{% trans "Description" %}</th>
+        </tr>
+        <tr>
+          <td>{% trans "Funder / Recipient" %}</td>
+          <td>{% trans "Funder or recipient name" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Funder Id / Recipient Id" %}</td>
+          <td>{% trans "Identifier code of the funder or recipient" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Grants" %}</td>
+          <td>{% trans "Number of grants made by/to the funder or recipient" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Total" %}</td>
+          <td>{% trans "Total value of all grants made by/to the funder or recipient" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Average" %}</td>
+          <td>{% trans "Average value of a grant made by/to the funder or recipient" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Largest" %}</td>
+          <td>{% trans "Value of the largest grant made by/to the funder or recipient" %}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Smallest" %}</td>
+          <td>{% trans "Value of the smallest grant made by/to the funder or recipient" %}</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+  <h2 id="advanced_search">{% trans "Advanced Search" %}</h2>
+
+  <p>{% blocktrans %}In addition to the freetext search, there are many ways you can search the data on this site.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Search for:{% endblocktrans %}</p>
+
+  <h3 id="words_phrases">{% trans "Words and phrases" %}</h3>
+  <ul>
+    <li>{% trans "A single word: e.g. people" %}</li>
+    <li>{% trans "All words: e.g. young people gardens" %}</li>
+    <li>{% trans "Require each word to be found: e.g. young AND people" %}</li>
+    <li>{% trans 'An exact phrase by enclosing it in quotes: e.g. "young people"' %}</li>
+  </ul>
+
+  <p>{% blocktrans %}Using the above you can effectively filter the records to a single publisher or an exact grant.<br>Try:{% endblocktrans %}</p>
+  <ul>
+    <li>"The Dulverton Trust"</li>
+    <li>"360G-wolfson-19750"</li>
+  </ul>
+
+  <h3 id="fields">{% trans "Fields" %}</h3>
+  <ul>
+    <li>{% blocktrans %}A specific field: e.g. title:gardens (will search the "title" field for the word "gardens"){% endblocktrans %}</li>
+    <li>{% blocktrans %}A field with no value (or is missing): e.g. missing:description (search the field "description" for grants that have no value (or is missing)){% endblocktrans %}</li>
+    <li>{% blocktrans %}A field that has any non-null value: e.g. exists:title{% endblocktrans %}</li>
+  </ul>
+  <p>{% blocktrans %}Fields are shown on many records. Others you might like to try:{% endblocktrans %}</p>
+  <ul>
+    <li>{% trans "title" %}</li>
+    <li>{% trans "description" %}</li>
+  </ul>
+
+  <p>{% blocktrans %}and see the list of field names via the <a href="/stats">stats</a>{% endblocktrans %}.</p>
+
+  <h3 id="ranges">{% trans "Ranges" %}</h3>
+  <h4>{% trans "Dates" %}</h4>
+
+  <p>{% blocktrans %}Find grants in a date range:{% endblocktrans %}</p>
+
+  <ul>
+    <li>{% blocktrans %}Planned start date in 2012: e.g. plannedDates.startDate:[2012-01-01 TO 2012-12-31]{% endblocktrans %}</li>
+    <li>{% blocktrans %}Planned start date in 2012 and planned end date in 2014: e.g. plannedDates.startDate:[2012-01-01 TO 2012-12-31] AND plannedDates.endDate:[2014-01-01 TO 2014-12-31]{% endblocktrans %}</li>
+  </ul>
+
+  <h4>{% trans "Amounts" %}</h4>
+
+  <ul>
+    <li>{% blocktrans %}Amount awarded between £0 and £100: e.g. amountAwarded:[0 TO 100]{% endblocktrans %}</li>
+    <li>{% blocktrans %}Amount awarded between £500 and £1000: e.g. amountAwarded:[500 TO 1000]{% endblocktrans %}</li>
+  </ul>
+
+  <p>{% blocktrans %}You can also search ranges with one side unbounded:{% endblocktrans %}</p>
+
+  <ul>
+    <li>{% blocktrans %}amountAwarded:>1000{% endblocktrans %}</li>
+    <li>{% blocktrans %}amountAwarded:>=1000{% endblocktrans %}</li>
+    <li>{% blocktrans %}amountAwarded::
+      <1000{% endblocktrans %}</li>
+        <li>{% blocktrans %}amountAwarded:
+          <=1000{% endblocktrans %}</li>
+  </ul>
+
+  <p>{% blocktrans %}You can also use the * wildcard (see below) when asking for a range: e.g. amountAwarded:[500 TO *]{% endblocktrans %}</p>
+
+  <h3 id="wildcards">{% trans "Wildcards" %}</h3>
+  <p>{% blocktrans %}Wildcard searches can be run on individual terms, using ? to replace a single character, and * to replace zero or more characters: e.g. b?g, you*{% endblocktrans %}</p>
+
+  <h3 id="fuzziness">{% trans "Fuzziness" %}</h3>
+  <p>{% blocktrans %}You can search for terms that are similar to, but not exactly like our search terms, using the “fuzzy” operator: e.g. youht~ yung~ pple~{% endblocktrans %}</p>
+
+  <!--<p>{% blocktrans %}For more examples and functionality see:
+  https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax{% endblocktrans %}</p>-->
+
+  {% endblock %}

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -232,72 +232,72 @@
 
   <h2 id="advanced_search">{% trans "Advanced search" %}</h2>
 
-  <p>{% blocktrans %}In addition to the freetext search, there are many ways you can search the data on this site.{% endblocktrans %}</p>
-  <p>{% blocktrans %}Search for:{% endblocktrans %}</p>
+  <p>{% blocktrans %}In addition to the freetext search, there are many ways you can search the data on this site and target your search with more specific controls.{% endblocktrans %}</p>
 
   <h3 id="words_phrases">{% trans "Words and phrases" %}</h3>
   <ul>
-    <li>{% trans "A single word: e.g. people" %}</li>
-    <li>{% trans "All words: e.g. young people gardens" %}</li>
-    <li>{% trans "Require each word to be found: e.g. young AND people" %}</li>
-    <li>{% trans 'An exact phrase by enclosing it in quotes: e.g. "young people"' %}</li>
+    <li>{% trans "A single word: e.g. <code>people</code>" %}</li>
+    <li>{% trans "Multiple words: e.g. <code>young people gardens</code> (each word does not necessarily have to be present)" %}</li>
+    <li>{% trans "Require each word to be found: e.g. <code>young AND people</code>" %}</li>
+    <li>{% trans 'An exact phrase by enclosing it in quotes: e.g. <code>"young people"</code>' %}</li>
   </ul>
 
-  <p>{% blocktrans %}Using the above you can effectively filter the records to a single publisher or an exact grant.<br>Try:{% endblocktrans %}</p>
+  <p>{% blocktrans %}Using the above you can effectively filter the records to a single publisher or an exact grant. Try:{% endblocktrans %}</p>
   <ul>
-    <li>"The Dulverton Trust"</li>
-    <li>"360G-wolfson-19750"</li>
+    <li><code>"The Dulverton Trust"</code></li>
+    <li><code>"360G-wolfson-19750"</code></li>
   </ul>
 
   <h3 id="fields">{% trans "Fields" %}</h3>
   <ul>
-    <li>{% blocktrans %}A specific field: e.g. title:gardens (will search the "title" field for the word "gardens"){% endblocktrans %}</li>
-    <li>{% blocktrans %}A field with no value (or is missing): e.g. missing:description (search the field "description" for grants that have no value (or is missing)){% endblocktrans %}</li>
-    <li>{% blocktrans %}A field that has any non-null value: e.g. exists:title{% endblocktrans %}</li>
-  </ul>
-  <p>{% blocktrans %}Fields are shown on many records. Others you might like to try:{% endblocktrans %}</p>
-  <ul>
-    <li>{% trans "title" %}</li>
-    <li>{% trans "description" %}</li>
+    <li>{% blocktrans %}Search words and phrases limited to a specific field, for example:{% endblocktrans %}
+      <ul>
+        <li>{% blocktrans %}<code>title:gardens</code> will search the "title" field for the word "gardens"){% endblocktrans %}</li>
+        <li>{% blocktrans %}<code>recipientOrganization.postalCode:NW1</code> will search the for recipients within the "NW1" postcode district (where the field is populated){% endblocktrans %}</li>
+        <li>{% blocktrans %}<code>fundingOrganisation.name:"London Councils"</code> will search the "Funding Organisation:Name" field for "London Councils"{% endblocktrans %}</li>
+      </ul>
+    </li>
+    <!-- these search functions not working as expected --> <!--
+    <li>{% blocktrans %}Search for a field with no value (or is missing): e.g. <code>missing:amountAppliedFor</code> will search for grants where the "Amount Applied For" field has no value (or is missing altogether){% endblocktrans %}</li>
+    <li>{% blocktrans %}Search for a field that has any non-null value: e.g. <code>exists:grantProgramme.title</code>{% endblocktrans %} will search for grants where there is a value in the "Grant Programme:Title" field</li>
+   -->
   </ul>
 
-  <p>{% blocktrans %}and see the list of field names via the <a href="/stats">stats</a>{% endblocktrans %}.</p>
+  <p>{% blocktrans %}The field names used must match the machine-readable field names in the data. You can find a list of field names in use on the <a href="/stats">stats page</a>{% endblocktrans %}.</p>
 
   <h3 id="ranges">{% trans "Ranges" %}</h3>
   <h4>{% trans "Dates" %}</h4>
 
-  <p>{% blocktrans %}Find grants in a date range:{% endblocktrans %}</p>
+  <p>{% blocktrans %}Search for grants in a given date range:{% endblocktrans %}</p>
 
   <ul>
-    <li>{% blocktrans %}Planned start date in 2012: e.g. plannedDates.startDate:[2012-01-01 TO 2012-12-31]{% endblocktrans %}</li>
-    <li>{% blocktrans %}Planned start date in 2012 and planned end date in 2014: e.g. plannedDates.startDate:[2012-01-01 TO 2012-12-31] AND plannedDates.endDate:[2014-01-01 TO 2014-12-31]{% endblocktrans %}</li>
+    <li>{% blocktrans %}Planned start date in 2012: e.g. <code>plannedDates.startDate:[2012-01-01 TO 2012-12-31]</code>{% endblocktrans %}</li>
+    <li>{% blocktrans %}Planned start date in 2012 <strong>and</strong> planned end date in 2014: e.g. <code>plannedDates.startDate:[2012-01-01 TO 2012-12-31] AND plannedDates.endDate:[2014-01-01 TO 2014-12-31]</code>{% endblocktrans %}</li>
   </ul>
 
   <h4>{% trans "Amounts" %}</h4>
-
+  <p>{% blocktrans %}In addition to using the <a href="#filters">filters</a> on results, you can also search for grants by amount (awarded, applied for etc.) within a specific range:{% endblocktrans %}</p>
   <ul>
-    <li>{% blocktrans %}Amount awarded between £0 and £100: e.g. amountAwarded:[0 TO 100]{% endblocktrans %}</li>
-    <li>{% blocktrans %}Amount awarded between £500 and £1000: e.g. amountAwarded:[500 TO 1000]{% endblocktrans %}</li>
+    <li>{% blocktrans %}Amount Awarded between £0 and £150: e.g. <code>amountAwarded:[0 TO 150]</code>{% endblocktrans %}</li>
+    <li>{% blocktrans %}Amount Applied For between £800 and £1000: e.g. <code>amountAppliedFor:[800 TO 1000]</code>{% endblocktrans %}</li>
   </ul>
 
   <p>{% blocktrans %}You can also search ranges with one side unbounded:{% endblocktrans %}</p>
 
   <ul>
-    <li>{% blocktrans %}amountAwarded:>1000{% endblocktrans %}</li>
-    <li>{% blocktrans %}amountAwarded:>=1000{% endblocktrans %}</li>
-    <li>{% blocktrans %}amountAwarded::
-      <1000{% endblocktrans %}</li>
-        <li>{% blocktrans %}amountAwarded:
-          <=1000{% endblocktrans %}</li>
+    <li>{% blocktrans %}<code>amountAwarded:>1000</code> (more than 1000){% endblocktrans %}</li>
+    <li>{% blocktrans %}<code>amountAwarded:>=1000</code> (more than or equal to 1000){% endblocktrans %}</li>
+    <li>{% blocktrans %}<code>amountAppliedFor:<1000</code> (less than 1000){% endblocktrans %}</li>
+    <li>{% blocktrans %}<code>amountAppliedFor:<=1000</code> (less than or equal to 1000){% endblocktrans %}</li>
   </ul>
 
-  <p>{% blocktrans %}You can also use the * wildcard (see below) when asking for a range: e.g. amountAwarded:[500 TO *]{% endblocktrans %}</p>
+  <p>{% blocktrans %}You can also use the * wildcard (see below) when asking for a range: e.g. <code>amountAwarded:[500 TO *]</code>{% endblocktrans %}</p>
 
   <h3 id="wildcards">{% trans "Wildcards" %}</h3>
-  <p>{% blocktrans %}Wildcard searches can be run on individual terms, using ? to replace a single character, and * to replace zero or more characters: e.g. b?g, you*{% endblocktrans %}</p>
+  <p>{% blocktrans %}Wildcard searches can be run on individual terms, using ? to replace a single character, and * to replace zero or more characters: e.g. <code>b?g</code>, <code>you*</code>{% endblocktrans %}</p>
 
   <h3 id="fuzziness">{% trans "Fuzziness" %}</h3>
-  <p>{% blocktrans %}You can search for terms that are similar to, but not exactly like our search terms, using the “fuzzy” operator: e.g. youht~ yung~ pple~{% endblocktrans %}</p>
+  <p>{% blocktrans %}You can search for terms that are similar to, but not exactly like our search terms, using the “fuzzy” operator: e.g. <code>youht~</code>, <code>yung~</code>, <code>pple~</code>{% endblocktrans %}</p>
 
   <!--<p>{% blocktrans %}For more examples and functionality see:
   https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax{% endblocktrans %}</p>-->

--- a/grantnav/frontend/tests.py
+++ b/grantnav/frontend/tests.py
@@ -74,9 +74,9 @@ def test_stats(provenance_dataload, client):
     assert "379" in str(response.content)
 
 
-def test_advanced_search(provenance_dataload, client):
-    response = client.get('/advanced_search')
-    assert 'Advanced Search' in str(response.content)
+def test_help_page(provenance_dataload, client):
+    response = client.get('/help')
+    assert 'Using GrantNav' in str(response.content)
 
 
 def test_json_download(provenance_dataload, client):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -73,12 +73,12 @@ def test_home(provenance_dataload, server_url, browser):
     ('About'),
     ('Funders'),
     ('Recipients'),
+    ('Help with Using GrantNav'),
     ('Terms and Conditions'),
     ('Take Down Policy'),
     ('Data Used in GrantNav'),
     ('Reusing GrantNav Data'),
     ('Copyright'),
-    ('Advanced Search'),
     ('Developers')
     ])
 def test_footer_links(provenance_dataload, server_url, browser, link_text):
@@ -125,9 +125,9 @@ def test_take_down(server_url, browser):
     assert 'Take Down Policy' in browser.find_element_by_tag_name('h1').text
 
 
-def test_advanced_search(server_url, browser):
-    browser.get(server_url + '/advanced_search')
-    assert 'Advanced Search' in browser.find_element_by_tag_name('h1').text
+def test_help_page(server_url, browser):
+    browser.get(server_url + '/help')
+    assert 'Using GrantNav' in browser.find_element_by_tag_name('h1').text
 
 
 def test_developers(server_url, browser):

--- a/grantnav/frontend/urls.py
+++ b/grantnav/frontend/urls.py
@@ -35,7 +35,6 @@ urlpatterns = [
     url(r'^stats', views.stats, name='stats'),
     url(r'^take_down_policy', TemplateView.as_view(template_name='take_down_policy.html'), name='take_down_policy'),
     url(r'^terms', TemplateView.as_view(template_name='terms.html'), name='terms'),
-    url(r'^advanced_search', TemplateView.as_view(template_name='advanced_search.html'), name='advanced_search'),
     url(r'^help', TemplateView.as_view(template_name='help.html'), name="help"),
     url(r'^developers', TemplateView.as_view(template_name='developers.html'), name='developers'),
     url(r'^about', TemplateView.as_view(template_name='about.html'), name='about'),

--- a/grantnav/frontend/urls.py
+++ b/grantnav/frontend/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     url(r'^take_down_policy', TemplateView.as_view(template_name='take_down_policy.html'), name='take_down_policy'),
     url(r'^terms', TemplateView.as_view(template_name='terms.html'), name='terms'),
     url(r'^advanced_search', TemplateView.as_view(template_name='advanced_search.html'), name='advanced_search'),
+    url(r'^help', TemplateView.as_view(template_name='help.html'), name="help"),
     url(r'^developers', TemplateView.as_view(template_name='developers.html'), name='developers'),
     url(r'^about', TemplateView.as_view(template_name='about.html'), name='about'),
     url(r'^api/grants.json', views.api_grants, name='api.grants.json'),


### PR DESCRIPTION
- Create a "Help with Using GrantNav" page with text as agreed with 360
  - Combine the current "Advanced Search" page into this page
  - Add a table of contents with internal page links
  - Make the formatting of the Advanced Search part clearer, and make examples (a bit) more relevant
- Remove the now-redundant separate Advanced Search page
- Link from footer to new "Help with Using GrantNav" page (and delete the advanced search link)
- Fix tests to match