### PR TITLE
Fix a typo in help page example

### DIFF
--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -254,7 +254,7 @@
       <ul>
         <li>{% blocktrans %}<code>title:gardens</code> will search the "title" field for the word "gardens"{% endblocktrans %}</li>
         <li>{% blocktrans %}<code>recipientOrganization.postalCode:NW1</code> will search the for recipients within the "NW1" postcode district (where the field is populated){% endblocktrans %}</li>
-        <li>{% blocktrans %}<code>fundingOrganisation.name:"London Councils"</code> will search the "Funding Organisation:Name" field for "London Councils"{% endblocktrans %}</li>
+        <li>{% blocktrans %}<code>fundingOrganization.name:"London Councils"</code> will search the "Funding Organisation:Name" field for "London Councils"{% endblocktrans %}</li>
       </ul>
     </li>
     <!-- these search functions not working as expected --> <!--


### PR DESCRIPTION
Small typo I made in the spelling of "fundingOrgani**z**ation" which meant that this example is incorrect