### PR TITLE
the 360Giving Company Number in the footer is wrong

### DIFF
--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -109,7 +109,7 @@
         </div>
         <div class="row">
           <div class="col-sm-12">
-            <p class="footer-info">360Giving is a company limited by guarantee (Company Number 9668396) and a registered charity (Charity Number 1164883)</p>
+            <p class="footer-info">360Giving is a company limited by guarantee (Company Number <a href="https://beta.companieshouse.gov.uk/company/09668396">09668396</a>) and a registered charity (Charity Number <a href="http://beta.charitycommission.gov.uk/charity-details/?regid=1164883&subid=0">1164883</a>)</p>
           </div>
         </div>
          <div class="row">


### PR DESCRIPTION
The zero is missing from the front of the number. Is this an in-joke?

Also, I added links to the respective pages on Co House and Charity Commission