### PR TITLE
15540-37 'and' vs 'or' queries [WIP - do not merge]

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -86,6 +86,7 @@ body .advanced-search-info {
   border: 1px solid #ccc;
   border-radius: 4px;
   font-family: Courier;
+  word-break: normal;
 }
 
 /* Issue #194 */

--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -73,6 +73,21 @@ a.list-group-item {
   background: white !important
 }
 
+body .advanced-search-info {
+  display: block;
+  padding: 9.5px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #333;
+  word-break: break-all;
+  word-wrap: break-word;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: Courier;
+}
+
 /* Issue #194 */
 td.amount {
   text-align: right;

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -32,6 +32,13 @@
       </form>
     </div>
   </div>
+
+  {% if search_help %}
+  <div>
+    <p>{{ search_help }}</p>
+  </div>
+  {% endif %}
+
   {% if selected_facets %}
   <div class="row">
     <div class="col-xs-12">

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -34,7 +34,7 @@
       {% if advanced_search_info %}
       <div class="col-xs-10">
         <p>
-          {{ advanced_search_info }}
+          Tip: {{ advanced_search_info }}
           <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
         </p>
       </div>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -30,16 +30,6 @@
           </div>
         </div>
       </form>
-
-      {% if advanced_search_info %}
-      <div class="col-xs-10">
-        <p>
-          Tip: {{ advanced_search_info }}
-          <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
-        </p>
-      </div>
-      {% endif %}
-
     </div>
   </div>
 
@@ -259,6 +249,17 @@
           </div>
         </div>
       </div>
+
+      {% if advanced_search_info %}
+      <div class="row">
+        <div class="col-sm-12">
+          <p class="advanced-search-info">
+            <strong>Tip:</strong> {{ advanced_search_info }}
+            <br><a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
+          </p>
+        </div>
+      </div>
+      {% endif %}
 
          <div class="panel panel-default">
             <div class="panel-body panel-no-padding">

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -31,11 +31,11 @@
         </div>
       </form>
 
-      {% if advance_search_info %}
+      {% if advanced_search_info %}
       <div class="col-xs-10">
         <p>
-          {{ advance_search_info }}
-          <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advance_search">Advance Search</a>
+          {{ advanced_search_info }}
+          <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
         </p>
       </div>
       {% endif %}

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -79,7 +79,7 @@
       <div class="col-xs-12">
         <p class="advanced-search-info">
           <strong>Tip:</strong> {{ advanced_search_info }}
-          <br><a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
+          For more tips, see <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
         </p>
       </div>
     {% endif %}

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -34,9 +34,13 @@
   </div>
 
   {% if advance_search_info %}
-  <div>
-    <p>{{ advance_search_info }}</p>
-    <a href="http://grantnav.threesixtygiving.org/help#advanced_search">Advance Search</a>
+  <div class="container">
+    <div class="row">
+      <p>
+        {{ advance_search_info }}
+        <a href="http://grantnav.threesixtygiving.org/help#advanced_search">Advance Search</a>
+      </p>
+    </div>
   </div>
   {% endif %}
 

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -33,9 +33,9 @@
     </div>
   </div>
 
-  {% if search_help %}
+  {% if advance_search_info %}
   <div>
-    <p>{{ search_help }}</p>
+    <p>{{ advance_search_info }}</p>
     <a href="http://grantnav.threesixtygiving.org/help#advanced_search">Advance Search</a>
   </div>
   {% endif %}

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -36,6 +36,7 @@
   {% if search_help %}
   <div>
     <p>{{ search_help }}</p>
+    <a href="http://grantnav.threesixtygiving.org/help#advanced_search">Advance Search</a>
   </div>
   {% endif %}
 

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -75,6 +75,15 @@
 
   
   <div class="row">
+    {% if advanced_search_info %}
+      <div class="col-xs-12">
+        <p class="advanced-search-info">
+          <strong>Tip:</strong> {{ advanced_search_info }}
+          <br><a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
+        </p>
+      </div>
+    {% endif %}
+
     <div class="col-xs-3 filters">
       <h3 class="indent"> Filter By </h3>
       <div class="panel panel-default">
@@ -249,17 +258,6 @@
           </div>
         </div>
       </div>
-
-      {% if advanced_search_info %}
-      <div class="row">
-        <div class="col-sm-12">
-          <p class="advanced-search-info">
-            <strong>Tip:</strong> {{ advanced_search_info }}
-            <br><a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advanced_search">Advanced Search</a>
-          </p>
-        </div>
-      </div>
-      {% endif %}
 
          <div class="panel panel-default">
             <div class="panel-body panel-no-padding">

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -30,19 +30,19 @@
           </div>
         </div>
       </form>
+
+      {% if advance_search_info %}
+      <div class="col-xs-10">
+        <p>
+          {{ advance_search_info }}
+          <a href="http://grantnav.threesixtygiving.org/help#advanced_search" class="advance_search">Advance Search</a>
+        </p>
+      </div>
+      {% endif %}
+
     </div>
   </div>
 
-  {% if advance_search_info %}
-  <div class="container">
-    <div class="row">
-      <p>
-        {{ advance_search_info }}
-        <a href="http://grantnav.threesixtygiving.org/help#advanced_search">Advance Search</a>
-      </p>
-    </div>
-  </div>
-  {% endif %}
 
   {% if selected_facets %}
   <div class="row">

--- a/grantnav/frontend/tests.py
+++ b/grantnav/frontend/tests.py
@@ -56,7 +56,7 @@ def test_search(provenance_dataload, client):
     json_query['query']['bool']['filter'][0]['bool']['should'] = [{'term': {'fundingOrganization.id_and_name': '["Wolfson Foundation", "GB-CHC-1156077"]'}}]
     assert json.loads(urllib.parse.parse_qs(wolfson_facet['url'].split('?')[-1])['json_query'][0]) == json_query
 
-    # click agian
+    # click again
     response = client.get(wolfson_facet['url'])
     wolfson_facet = response.context['results']['aggregations']['fundingOrganization']['buckets'][0]
     assert wolfson_facet['doc_count'] == 8

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -235,7 +235,7 @@ def test_search_display_advanced_search_link(provenance_dataload, server_url, br
     search_box.send_keys('social change')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'Advanced Search' in browser.find_element_by_tag_name('body').text
+    assert 'For more tips, see Advanced Search' in browser.find_element_by_tag_name('body').text
 
 
 def test_search_advanced_search_correct_link(provenance_dataload, server_url, browser):
@@ -254,7 +254,7 @@ def test_search_do_not_display_advance_search_link(provenance_dataload, server_u
     search_box.send_keys('grant')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'Advance Search' not in browser.find_element_by_tag_name('body').text
+    assert 'For more tips, see Advanced Search' not in browser.find_element_by_tag_name('body').text
 
 
 def test_bad_search(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -111,9 +111,9 @@ def test_search(provenance_dataload, server_url, browser):
     assert "$146,325" in browser.find_element_by_tag_name('body').text
 
 
-def test_search_two_words(provenance_dataload, server_url, browser):
+def test_search_two_words_without_quotes(provenance_dataload, server_url, browser):
     """
-    A user search query is 2+ words (eg. social change) without quotes.
+    when a user search query is 2+ words (eg. social change) without quotes,
     we want to inform the user that with quotes will have a better search result.
     """
     browser.get(server_url)
@@ -124,6 +124,28 @@ def test_search_two_words(provenance_dataload, server_url, browser):
     current_url_split_by_json_query = browser.current_url.split('?')
     assert current_url_split_by_json_query[0][-6:] == 'search'
     assert 'If you use quotes around your search, the result will be more accurate.' in browser.find_element_by_tag_name('body').text
+
+
+def test_search_two_words_with_single_quotes(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys("'social change'")
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
+
+
+def test_search_two_words_with_double_quotes(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('"social change"')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
 
 
 def test_bad_search(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -121,7 +121,7 @@ def test_search_current_url(provenance_dataload, server_url, browser):
 
 def test_search_two_words_without_quotes(provenance_dataload, server_url, browser):
     """
-    when a user search query is 2+ words (eg. social change) without quotes,
+    When a user's search query is 2+ words without quotes,
     we want to inform the user that with quotes will have a better search result.
     """
     browser.get(server_url)
@@ -151,6 +151,9 @@ def test_search_two_words_with_double_quotes(provenance_dataload, server_url, br
 
 
 def test_search_includes_and(provenance_dataload, server_url, browser):
+    """
+    When a user's search query includes 'and', we want to inform the user of what it means.
+    """
     browser.get(server_url)
     search_box = browser.find_element_by_class_name("large-search")
     search_box.send_keys('mental and health')
@@ -169,6 +172,9 @@ def test_search_does_not_include_and(provenance_dataload, server_url, browser):
 
 
 def test_search_includes_or(provenance_dataload, server_url, browser):
+    """
+    When a user's search query includes 'or', we want to inform the user of what it means.
+    """
     browser.get(server_url)
     search_box = browser.find_element_by_class_name("large-search")
     search_box.send_keys('mental or health')
@@ -187,6 +193,10 @@ def test_search_does_not_include_or(provenance_dataload, server_url, browser):
 
 
 def test_search_display_advance_search_link(provenance_dataload, server_url, browser):
+    """
+    When an advance search message is displayed in the search results,
+    a link to the 'advance search' information page is also included.
+    """
     browser.get(server_url)
     search_box = browser.find_element_by_class_name("large-search")
     search_box.send_keys('social change')

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -129,7 +129,8 @@ def test_search_two_words_without_quotes(provenance_dataload, server_url, browse
     search_box.send_keys('social change')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'If you use quotes around your search, the result will be more accurate.' in browser.find_element_by_tag_name('body').text
+    assert 'If you\'re looking for a specific phrase, put quotes around it to refine your search. e.g. "youth clubs".' \
+           in browser.find_element_by_tag_name('body').text
 
 
 def test_search_two_words_with_single_quotes(provenance_dataload, server_url, browser):
@@ -138,7 +139,8 @@ def test_search_two_words_with_single_quotes(provenance_dataload, server_url, br
     search_box.send_keys("'social change'")
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
+    assert 'If you\'re looking for a specific phrase, put quotes around it to refine your search. e.g. "youth clubs".' \
+           not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_two_words_with_double_quotes(provenance_dataload, server_url, browser):
@@ -147,7 +149,8 @@ def test_search_two_words_with_double_quotes(provenance_dataload, server_url, br
     search_box.send_keys('"social change"')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
+    assert 'If you\'re looking for a specific phrase, put quotes around it to refine your search. e.g. "youth clubs".' \
+           not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_includes_and(provenance_dataload, server_url, browser):
@@ -159,7 +162,9 @@ def test_search_includes_and(provenance_dataload, server_url, browser):
     search_box.send_keys('mental and health')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert '"And" requires each word to be found' in browser.find_element_by_tag_name('body').text
+    assert 'The AND keyword (not case-sensitive) means that results must have both words present. ' \
+           'If you\'re looking for a phrase that has the word "and" in it, put quotes around the phrase ' \
+           '(e.g. "fees and costs").' in browser.find_element_by_tag_name('body').text
 
 
 def test_search_does_not_include_and(provenance_dataload, server_url, browser):
@@ -168,7 +173,9 @@ def test_search_does_not_include_and(provenance_dataload, server_url, browser):
     search_box.send_keys('secondhand clothes')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert '"And" requires each word to be found' not in browser.find_element_by_tag_name('body').text
+    assert 'The AND keyword (not case-sensitive) means that results must have both words present. ' \
+           'If you\'re looking for a phrase that has the word "and" in it, put quotes around the phrase ' \
+           '(e.g. "fees and costs").' not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_includes_or(provenance_dataload, server_url, browser):
@@ -180,7 +187,9 @@ def test_search_includes_or(provenance_dataload, server_url, browser):
     search_box.send_keys('mental or health')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert '"Or" requires one of the two words to be found' in browser.find_element_by_tag_name('body').text
+    assert 'The OR keyword (not case-sensitive) means that results must have one of the words present. ' \
+           'This is the default. If you\'re looking for a phrase that has the word "or" in (e.g. "NYC or bust"), ' \
+           'put quotes around it.' in browser.find_element_by_tag_name('body').text
 
 
 def test_search_does_not_include_or(provenance_dataload, server_url, browser):
@@ -189,7 +198,31 @@ def test_search_does_not_include_or(provenance_dataload, server_url, browser):
     search_box.send_keys('meteor clothes')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert '"Or" requires one of the two words to be found' not in browser.find_element_by_tag_name('body').text
+    assert 'The OR keyword (not case-sensitive) means that results must have one of the words present. ' \
+           'This is the default. If you\'re looking for a phrase that has the word "or" in (e.g. "NYC or bust"), ' \
+           'put quotes around it.' not in browser.find_element_by_tag_name('body').text
+
+
+def test_search_display_tip(provenance_dataload, server_url, browser):
+    """
+    When an advance search message is displayed in the search results,
+    'Tip: ' will appear in front of the message.
+    """
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('social change')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert 'Tip: ' in browser.find_element_by_tag_name('body').text
+
+
+def test_search_do_not_display_tip(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('grant')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert 'Tip: ' not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_display_advanced_search_link(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -111,6 +111,21 @@ def test_search(provenance_dataload, server_url, browser):
     assert "$146,325" in browser.find_element_by_tag_name('body').text
 
 
+def test_search_two_words(provenance_dataload, server_url, browser):
+    """
+    A user search query is 2+ words (eg. social change) without quotes.
+    we want to inform the user that with quotes will have a better search result.
+    """
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('social change')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert 'If you use quotes around your search, the result will be more accurate.' in browser.find_element_by_tag_name('body').text
+
+
 def test_bad_search(provenance_dataload, server_url, browser):
     browser.get(server_url)
     browser.find_element_by_name("text_query").send_keys(" £s:::::afdsfas")

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -148,6 +148,50 @@ def test_search_two_words_with_double_quotes(provenance_dataload, server_url, br
     assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
 
 
+def test_search_includes_and(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('mental and health')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert '"And" requires each word to be found' in browser.find_element_by_tag_name('body').text
+
+
+def test_search_does_not_include_and(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('secondhand clothes')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert '"And" requires each word to be found' not in browser.find_element_by_tag_name('body').text
+
+
+def test_search_includes_or(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('mental or health')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert '"Or" requires one of the two words to be found' in browser.find_element_by_tag_name('body').text
+
+
+def test_search_does_not_include_or(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('meteor clothes')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+    assert '"Or" requires one of the two words to be found' not in browser.find_element_by_tag_name('body').text
+
+
 def test_bad_search(provenance_dataload, server_url, browser):
     browser.get(server_url)
     browser.find_element_by_name("text_query").send_keys(" £s:::::afdsfas")

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -192,7 +192,7 @@ def test_search_does_not_include_or(provenance_dataload, server_url, browser):
     assert '"Or" requires one of the two words to be found' not in browser.find_element_by_tag_name('body').text
 
 
-def test_search_display_advance_search_link(provenance_dataload, server_url, browser):
+def test_search_display_advanced_search_link(provenance_dataload, server_url, browser):
     """
     When an advance search message is displayed in the search results,
     a link to the 'advance search' information page is also included.
@@ -202,15 +202,15 @@ def test_search_display_advance_search_link(provenance_dataload, server_url, bro
     search_box.send_keys('social change')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert 'Advance Search' in browser.find_element_by_tag_name('body').text
+    assert 'Advanced Search' in browser.find_element_by_tag_name('body').text
 
 
-def test_search_advance_search_correct_link(provenance_dataload, server_url, browser):
+def test_search_advanced_search_correct_link(provenance_dataload, server_url, browser):
     browser.get(server_url)
     search_box = browser.find_element_by_class_name("large-search")
     search_box.send_keys('social change')
     browser.find_element_by_class_name("large-search-icon").click()
-    browser.find_element_by_class_name("advance_search").click()
+    browser.find_element_by_class_name("advanced_search").click()
 
     assert browser.current_url == 'http://grantnav.threesixtygiving.org/help#advanced_search'
 

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -111,6 +111,14 @@ def test_search(provenance_dataload, server_url, browser):
     assert "$146,325" in browser.find_element_by_tag_name('body').text
 
 
+def test_search_current_url(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    current_url_split_by_json_query = browser.current_url.split('?')
+    assert current_url_split_by_json_query[0][-6:] == 'search'
+
+
 def test_search_two_words_without_quotes(provenance_dataload, server_url, browser):
     """
     when a user search query is 2+ words (eg. social change) without quotes,
@@ -121,8 +129,6 @@ def test_search_two_words_without_quotes(provenance_dataload, server_url, browse
     search_box.send_keys('social change')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert 'If you use quotes around your search, the result will be more accurate.' in browser.find_element_by_tag_name('body').text
 
 
@@ -132,8 +138,6 @@ def test_search_two_words_with_single_quotes(provenance_dataload, server_url, br
     search_box.send_keys("'social change'")
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
 
 
@@ -143,8 +147,6 @@ def test_search_two_words_with_double_quotes(provenance_dataload, server_url, br
     search_box.send_keys('"social change"')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert 'If you use quotes around your search, the result will be more accurate.' not in browser.find_element_by_tag_name('body').text
 
 
@@ -154,8 +156,6 @@ def test_search_includes_and(provenance_dataload, server_url, browser):
     search_box.send_keys('mental and health')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert '"And" requires each word to be found' in browser.find_element_by_tag_name('body').text
 
 
@@ -165,8 +165,6 @@ def test_search_does_not_include_and(provenance_dataload, server_url, browser):
     search_box.send_keys('secondhand clothes')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert '"And" requires each word to be found' not in browser.find_element_by_tag_name('body').text
 
 
@@ -176,8 +174,6 @@ def test_search_includes_or(provenance_dataload, server_url, browser):
     search_box.send_keys('mental or health')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert '"Or" requires one of the two words to be found' in browser.find_element_by_tag_name('body').text
 
 
@@ -187,9 +183,35 @@ def test_search_does_not_include_or(provenance_dataload, server_url, browser):
     search_box.send_keys('meteor clothes')
     browser.find_element_by_class_name("large-search-icon").click()
 
-    current_url_split_by_json_query = browser.current_url.split('?')
-    assert current_url_split_by_json_query[0][-6:] == 'search'
     assert '"Or" requires one of the two words to be found' not in browser.find_element_by_tag_name('body').text
+
+
+def test_search_display_advance_search_link(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('social change')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert 'Advance Search' in browser.find_element_by_tag_name('body').text
+
+
+def test_search_advance_search_correct_link(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('social change')
+    browser.find_element_by_class_name("large-search-icon").click()
+    browser.find_element_by_class_name("advance_search").click()
+
+    assert browser.current_url == 'http://grantnav.threesixtygiving.org/help#advanced_search'
+
+
+def test_search_do_not_display_advance_search_link(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('grant')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert 'Advance Search' not in browser.find_element_by_tag_name('body').text
 
 
 def test_bad_search(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -566,8 +566,12 @@ def search(request):
 
         context['selected_facets'] = dict(context['selected_facets'])
 
-        if context.get('text_query') is not None and ' ' in context.get('text_query'):
-            context["search_help"] = 'If you use quotes around your search, the result will be more accurate.'
+        text_query = context.get('text_query')
+        if text_query is not None and len(text_query) > 1:
+            if ' ' in context.get('text_query') \
+                    and not (text_query.startswith("'") and text_query.endswith("'")) \
+                    and not (text_query.startswith('"') and text_query.endswith('"')):
+                context["search_help"] = 'If you use quotes around your search, the result will be more accurate.'
 
         return render(request, "search.html", context=context)
 

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -430,8 +430,8 @@ def home(request):
 
 def add_advance_search_information_in_context(context):
     """
-    When a user search query is 2+ words without quotes, with 'and' or 'or'.
-    We give the user advance search information.
+    When a user's search query is 2+ words without quotes, with 'and' or 'or'.
+    Advanced search information is displayed.
     """
     text_query = context.get('text_query').lower()
     if text_query is not None and len(text_query) > 1:
@@ -452,7 +452,6 @@ def search(request):
     context = {}
 
     query = request.GET.urlencode()
-
     if query:
         context['query_string'] = query
     else:

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -428,6 +428,24 @@ def home(request):
     return render(request, "home.html", context=context)
 
 
+def add_advance_search_information_in_context(context):
+    """
+    When a user search query is 2+ words without quotes, with 'and' or 'or'.
+    We give the user advance search information.
+    """
+    text_query = context.get('text_query').lower()
+    if text_query is not None and len(text_query) > 1:
+        if re.search(r'\b and \b', text_query):
+            context["advance_search_info"] = '"And" requires each word to be found'
+        elif re.search(r'\b or \b', text_query):
+            context["advance_search_info"] = '"Or" requires one of the two words to be found'
+        elif ' ' in context.get('text_query') \
+                and not (text_query.startswith("'") and text_query.endswith("'")) \
+                and not (text_query.startswith('"') and text_query.endswith('"')):
+            context["advance_search_info"] = 'If you use quotes around your search, the result will be more accurate.'
+    return context
+
+
 def search(request):
     [result_format, results_size] = get_request_type_and_size(request)
 
@@ -568,16 +586,7 @@ def search(request):
 
         context['selected_facets'] = dict(context['selected_facets'])
 
-        text_query = context.get('text_query').lower()
-        if text_query is not None and len(text_query) > 1:
-            if re.search(r'\b and \b', text_query):
-                context["search_help"] = '"And" requires each word to be found'
-            elif re.search(r'\b or \b', text_query):
-                context["search_help"] = '"Or" requires one of the two words to be found'
-            elif ' ' in context.get('text_query') \
-                    and not (text_query.startswith("'") and text_query.endswith("'")) \
-                    and not (text_query.startswith('"') and text_query.endswith('"')):
-                context["search_help"] = 'If you use quotes around your search, the result will be more accurate.'
+        add_advance_search_information_in_context(context)
 
         return render(request, "search.html", context=context)
 

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -428,7 +428,7 @@ def home(request):
     return render(request, "home.html", context=context)
 
 
-def add_advance_search_information_in_context(context):
+def add_advanced_search_information_in_context(context):
     """
     When a user's search query is 2+ words without quotes, with 'and' or 'or'.
     Advanced search information is displayed.
@@ -436,13 +436,13 @@ def add_advance_search_information_in_context(context):
     text_query = context.get('text_query').lower()
     if text_query is not None and len(text_query) > 1:
         if re.search(r'\b and \b', text_query):
-            context["advance_search_info"] = '"And" requires each word to be found'
+            context["advanced_search_info"] = '"And" requires each word to be found'
         elif re.search(r'\b or \b', text_query):
-            context["advance_search_info"] = '"Or" requires one of the two words to be found'
+            context["advanced_search_info"] = '"Or" requires one of the two words to be found'
         elif ' ' in context.get('text_query') \
                 and not (text_query.startswith("'") and text_query.endswith("'")) \
                 and not (text_query.startswith('"') and text_query.endswith('"')):
-            context["advance_search_info"] = 'If you use quotes around your search, the result will be more accurate.'
+            context["advanced_search_info"] = 'If you use quotes around your search, the result will be more accurate.'
     return context
 
 
@@ -585,7 +585,7 @@ def search(request):
 
         context['selected_facets'] = dict(context['selected_facets'])
 
-        add_advance_search_information_in_context(context)
+        add_advanced_search_information_in_context(context)
 
         return render(request, "search.html", context=context)
 

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -427,12 +427,12 @@ def home(request):
 
 
 def search(request):
-
     [result_format, results_size] = get_request_type_and_size(request)
 
     context = {}
 
     query = request.GET.urlencode()
+
     if query:
         context['query_string'] = query
     else:
@@ -565,6 +565,9 @@ def search(request):
         get_pagination(request, context, page)
 
         context['selected_facets'] = dict(context['selected_facets'])
+
+        if context.get('text_query') is not None and ' ' in context.get('text_query'):
+            context["search_help"] = 'If you use quotes around your search, the result will be more accurate.'
 
         return render(request, "search.html", context=context)
 

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -436,13 +436,18 @@ def add_advanced_search_information_in_context(context):
     text_query = context.get('text_query').lower()
     if text_query is not None and len(text_query) > 1:
         if re.search(r'\b and \b', text_query):
-            context["advanced_search_info"] = '"And" requires each word to be found'
+            context["advanced_search_info"] = 'The AND keyword (not case-sensitive) means that results must have ' \
+                'both words present. If you\'re looking for a phrase that has the word "and" in it, put quotes ' \
+                'around the phrase (e.g. "fees and costs").'
         elif re.search(r'\b or \b', text_query):
-            context["advanced_search_info"] = '"Or" requires one of the two words to be found'
+            context["advanced_search_info"] = 'The OR keyword (not case-sensitive) means that results must have one ' \
+                'of the words present. This is the default. If you\'re looking for a phrase that has the word "or" ' \
+                'in (e.g. "NYC or bust"), put quotes around it.'
         elif ' ' in context.get('text_query') \
                 and not (text_query.startswith("'") and text_query.endswith("'")) \
                 and not (text_query.startswith('"') and text_query.endswith('"')):
-            context["advanced_search_info"] = 'If you use quotes around your search, the result will be more accurate.'
+            context["advanced_search_info"] = 'If you\'re looking for a specific phrase, put quotes around it to ' \
+                'refine your search. e.g. "youth clubs".'
     return context
 
 


### PR DESCRIPTION
Problem:
When a user searches for 'music therapy' (without quotes), the results can include 'music' or 'therapy'.
When a user searches for 'music therapy' (with quotes), the results include both words.
User could use 'and' or 'or' without knowing the impact in the search.

Solution:
Display information messages in those cases. The messages are a proposal, you can make better recommendations.

Without quotes:
'If you use quotes around your search, the result will be more accurate.'
And:
'"And" requires each word to be found'
Or:
'"Or" requires one of the two words to be found'


<img width="1305" alt="screen shot 2018-07-06 at 12 22 02" src="https://user-images.githubusercontent.com/9610927/42376899-c07b6436-8118-11e8-91c2-2c801d8abf3f.png">
