### PR TITLE
479 search titles and desc

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -341,7 +341,9 @@ def update_doc_with_title_and_description(grant):
     """
     Update ElasticSearch with the new key 'title_and_description'.
     """
-    grant['title_and_description'] = json.dumps([grant.get('title'), grant.get('description')])
+    description = grant.get('description') if grant.get('description') else ''
+    title = grant.get('title') if grant.get('title') else ''
+    grant['title_and_description'] = title + ' ' + description
 
 
 def update_doc_with_org_mappings(grant, org_key, file_name):

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -89,7 +89,7 @@ def import_to_elasticsearch(files, clean):
                 "recipientDistrictName": {"type": "string", "index": "not_analyzed"},
                 "recipientWardName": {"type": "string", "index": "not_analyzed"},
                 "currency": {"type": "string", "index": "not_analyzed"},
-                "title_and_description": {"type": "string"},
+                "title_and_description": {"type": "string", "analyzer": "english_with_folding"},
                 "recipientLocation": {"type": "string"},
                 "amountAppliedFor": {"type": "double"},
                 "amountAwarded": {"type": "double"},

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -89,6 +89,7 @@ def import_to_elasticsearch(files, clean):
                 "recipientDistrictName": {"type": "string", "index": "not_analyzed"},
                 "recipientWardName": {"type": "string", "index": "not_analyzed"},
                 "currency": {"type": "string", "index": "not_analyzed"},
+                "title_and_description": {"type": "string"},
                 "recipientLocation": {"type": "string"},
                 "amountAppliedFor": {"type": "double"},
                 "amountAwarded": {"type": "double"},
@@ -254,6 +255,7 @@ def import_to_elasticsearch(files, clean):
                     update_doc_with_org_mappings(grant, "fundingOrganization", file_name)
                     update_doc_with_org_mappings(grant, "recipientOrganization", file_name)
                     update_doc_with_region(grant)
+                    update_doc_with_title_and_description(grant)
                     currency = grant.get('currency')
                     if currency:
                         grant['currency'] = currency.upper()
@@ -333,6 +335,13 @@ def update_doc_with_region(grant):
             if geoCode and geoCode.startswith("N09"):
                 grant['recipientRegionName'] = "Northern Ireland"
                 grant['recipientDistrictName'] = location["name"]
+
+
+def update_doc_with_title_and_description(grant):
+    """
+    Update ElasticSearch with the new key 'title_and_description'.
+    """
+    grant['title_and_description'] = json.dumps([grant.get('title'), grant.get('description')])
 
 
 def update_doc_with_org_mappings(grant, org_key, file_name):

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -179,12 +179,12 @@ def import_to_elasticsearch(files, clean):
                 "english_with_folding": {
                     "tokenizer": "standard",
                     "filter": [
+                        # asciifolding not in the standard english analyzer.
+                        "asciifolding",
                         "english_possessive_stemmer",
                         "lowercase",
                         "english_stop",
                         "english_stemmer",
-                        # Additional filters not in the standard english analyzer:
-                        "asciifolding",
                     ]
                 }
             },

--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -187,7 +187,7 @@ table.dataTable.dtr-inline.collapsed > tbody > tr.parent > td:first-child::befor
 select.front_search	{
   display: inline-block;
   vertical-align: top;
-  width: 20%;
+  width: 24%;
   background-color: #d66f05;
   border-radius: 12px;
   height: 79px;

--- a/grantnav/frontend/static/css/theme.css
+++ b/grantnav/frontend/static/css/theme.css
@@ -6153,7 +6153,7 @@ input:-moz-placeholder {
 .large-search {
   display: inline-block;
   vertical-align: top;
-  width: 79%;
+  width: 75%;
   margin: 0 auto;
   padding: 10px 20px;
   border-radius: 12px;

--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -46,15 +46,19 @@
             <td>{% trans "Searches across all fields - covering text and numbers." %}</td>
           </tr>
           <tr>
-            <td>{% trans "Only Locations" %}</td>
+            <td>{% trans "Locations" %}</td>
             <td>
               <p>{% trans "Searches the ward, district and region location of the recipient organisation, of any grant record which features this geographical information." %}</p>
               <p>{% blocktrans %}See also: <a href="#location_data">GrantNav and location data</a>{% endblocktrans %}</p>
             </td>
           </tr>
           <tr>
-            <td>{% trans "Only Recipients" %}</td>
+            <td>{% trans "Recipients" %}</td>
             <td>{% trans "Searches the name of the recipient organisation only." %}</td>
+          </tr>
+          <tr>
+            <td>{% trans "Titles and Descriptions" %}</td>
+            <td>{% trans "Searches the title and description of the recipient organisation only." %}</td>
           </tr>
         </tbody>
       </table>

--- a/grantnav/frontend/templates/home.html
+++ b/grantnav/frontend/templates/home.html
@@ -18,7 +18,7 @@
 					<option name="default_field" id="inlineRadio1" value="_all">Search All</option>
 					<option name="default_field" id="inlineRadio2" value="recipientLocation">Only Locations</option>
 					<option name="default_field" id="inlineRadio3" value="recipientOrganization.name">Only Recipients</option>
-          <option name="default_field" id="inlineRadio4" value="Title">Only Titles</option>
+          <option name="default_field" id="inlineRadio4" value="title">Only Titles</option>
 				</select>
 				<input name="text_query" class="form-control large-search" placeholder="What are you searching for?" type="text">
 				<input class="large-search-icon" name="submit" src="{% static 'images/search_icon.png' %}" type="image" height="55px" width="55px">

--- a/grantnav/frontend/templates/home.html
+++ b/grantnav/frontend/templates/home.html
@@ -18,7 +18,7 @@
 					<option name="default_field" id="inlineRadio1" value="_all">Search All</option>
 					<option name="default_field" id="inlineRadio2" value="recipientLocation">Only Locations</option>
 					<option name="default_field" id="inlineRadio3" value="recipientOrganization.name">Only Recipients</option>
-          <option name="default_field" id="inlineRadio4" value="title">Only Titles</option>
+          <option name="default_field" id="inlineRadio4" value="title_and_description">Only Titles & Descriptions</option>
 				</select>
 				<input name="text_query" class="form-control large-search" placeholder="What are you searching for?" type="text">
 				<input class="large-search-icon" name="submit" src="{% static 'images/search_icon.png' %}" type="image" height="55px" width="55px">

--- a/grantnav/frontend/templates/home.html
+++ b/grantnav/frontend/templates/home.html
@@ -18,6 +18,7 @@
 					<option name="default_field" id="inlineRadio1" value="_all">Search All</option>
 					<option name="default_field" id="inlineRadio2" value="recipientLocation">Only Locations</option>
 					<option name="default_field" id="inlineRadio3" value="recipientOrganization.name">Only Recipients</option>
+          <option name="default_field" id="inlineRadio4" value="Title">Only Titles</option>
 				</select>
 				<input name="text_query" class="form-control large-search" placeholder="What are you searching for?" type="text">
 				<input class="large-search-icon" name="submit" src="{% static 'images/search_icon.png' %}" type="image" height="55px" width="55px">

--- a/grantnav/frontend/templates/home.html
+++ b/grantnav/frontend/templates/home.html
@@ -14,11 +14,11 @@
 <!-- Dropdown -->
 		 <form role="search" action="{% url 'search' %}">
 			<div class="form-group">
-				<select name="default_field" class="front_search">
+				<select name="default_field" class="front_search selectpicker">
 					<option name="default_field" id="inlineRadio1" value="_all">Search All</option>
-					<option name="default_field" id="inlineRadio2" value="recipientLocation">Only Locations</option>
-					<option name="default_field" id="inlineRadio3" value="recipientOrganization.name">Only Recipients</option>
-          <option name="default_field" id="inlineRadio4" value="title_and_description">Only Titles & Descriptions</option>
+					<option name="default_field" id="inlineRadio2" value="recipientLocation">Locations</option>
+					<option name="default_field" id="inlineRadio3" value="recipientOrganization.name">Recipients</option>
+          <option name="default_field" id="inlineRadio4" value="title_and_description">Titles & Descriptions</option>
 				</select>
 				<input name="text_query" class="form-control large-search" placeholder="What are you searching for?" type="text">
 				<input class="large-search-icon" name="submit" src="{% static 'images/search_icon.png' %}" type="image" height="55px" width="55px">

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -27,7 +27,7 @@
                 <input {% if default_field == "recipientOrganization.name" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio3" value="recipientOrganization.name"> Only Recipients
               </label>
               <label class="radio-inline">
-                <input {% if default_field == "Title" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="title"> Only Titles
+                <input {% if default_field == "title_and_description" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="title_and_description"> Only Titles & Descriptions
               </label>
             </div>
           </div>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -27,7 +27,7 @@
                 <input {% if default_field == "recipientOrganization.name" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio3" value="recipientOrganization.name"> Only Recipients
               </label>
               <label class="radio-inline">
-                <input {% if default_field == "Title" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="Title"> Only Titles
+                <input {% if default_field == "Title" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="title"> Only Titles
               </label>
             </div>
           </div>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -26,6 +26,9 @@
               <label class="radio-inline">
                 <input {% if default_field == "recipientOrganization.name" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio3" value="recipientOrganization.name"> Only Recipients
               </label>
+              <label class="radio-inline">
+                <input {% if default_field == "Title" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="Title"> Only Titles
+              </label>
             </div>
           </div>
         </div>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -21,13 +21,13 @@
                 <input {% if default_field == "_all" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio1" value="_all"> Search All Fields
               </label>
               <label class="radio-inline">
-                <input {% if default_field == "recipientLocation" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio2" value="recipientLocation"> Only Locations
+                <input {% if default_field == "recipientLocation" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio2" value="recipientLocation"> Locations
               </label>
               <label class="radio-inline">
-                <input {% if default_field == "recipientOrganization.name" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio3" value="recipientOrganization.name"> Only Recipients
+                <input {% if default_field == "recipientOrganization.name" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio3" value="recipientOrganization.name"> Recipients
               </label>
               <label class="radio-inline">
-                <input {% if default_field == "title_and_description" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="title_and_description"> Only Titles & Descriptions
+                <input {% if default_field == "title_and_description" %} checked {% endif %} type="radio" name="default_field" id="inlineRadio4" value="title_and_description"> Titles & Descriptions
               </label>
             </div>
           </div>

--- a/grantnav/frontend/templatetags/frontend.py
+++ b/grantnav/frontend/templatetags/frontend.py
@@ -1,14 +1,16 @@
-from collections import OrderedDict
-from django import template
-import math
 import datetime
-import dateutil.parser as date_parser
-import strict_rfc3339
 import json
+import math
+from collections import OrderedDict
+
+import dateutil.parser as date_parser
+import jsonref
+import strict_rfc3339
+from django import template
+from django.conf import settings
+
 from grantnav import provenance
 from grantnav import utils
-import jsonref
-from django.conf import settings
 
 register = template.Library()
 

--- a/grantnav/frontend/tests.py
+++ b/grantnav/frontend/tests.py
@@ -7,13 +7,13 @@ import requests
 
 from dataload.import_to_elasticsearch import import_to_elasticsearch, get_area_mappings
 
-prefix = 'https://raw.githubusercontent.com/OpenDataServices/grantnav-sampledata/560a8d9f21a069a9d51468850188f34ae72a0ec3/'
+prefix = 'https://raw.githubusercontent.com/OpenDataServices/grantnav-sampledata/c536a0ee750893fb53e7b458248fd8fd5913e9b5/'
 
 
 @pytest.fixture(scope="module")
 def dataload():
     get_area_mappings()
-    import_to_elasticsearch([prefix + 'a002400000KeYdsAAF.json'], clean=True)
+    import_to_elasticsearch([prefix + 'a002400000KeYdsAAF.json', prefix + 'grantnav-20180903134856.json'], clean=True)
     #elastic search needs some time to commit its data
     time.sleep(2)
 
@@ -38,13 +38,13 @@ def test_home(provenance_dataload, client, expected_text):
 
 
 def test_search(provenance_dataload, client):
-    initial_response = client.get('/search?text_query=gardens')
+    initial_response = client.get('/search?text_query=gardens+AND+fundingOrganization.id:GB-CHC-1156077')
     assert initial_response.status_code == 302
     response = client.get(initial_response.url)
     assert "Total grants" in str(response.content)
     assert "The British Museum" in str(response.content)
 
-    assert response.context['text_query'] == 'gardens'
+    assert response.context['text_query'] == 'gardens AND fundingOrganization.id:GB-CHC-1156077'
     assert response.context['results']['hits']['total'] == 8
 
     # click facet
@@ -66,13 +66,32 @@ def test_search(provenance_dataload, client):
 
     # Test the data is extended by grantnav adding geo codes
     # Original data contains postal codes only
-    geocode_response = client.get('/search?text_query=E10000023')
+    geocode_response = client.get('/search?text_query=E10000023+AND+fundingOrganization.id:GB-CHC-1156077')
     response = client.get(geocode_response.url)
     assert response.context['results']['hits']['total'] == 0
 
-    geocode_response = client.get('/search?text_query=E09000033')
+    geocode_response = client.get('/search?text_query=E09000033+AND+fundingOrganization.id:GB-CHC-1156077')
     response = client.get(geocode_response.url)
     assert response.context['results']['hits']['total'] == 19
+
+
+def test_search_accents(provenance_dataload, client):
+    # Check that accents placed in different positions give same result
+
+    initial_response = client.get('/search?text_query=Esmee')
+    response = client.get(initial_response.url)
+
+    assert response.context['results']['hits']['total'] == 5
+
+    initial_response = client.get('/search?text_query=Esmée')
+    response = client.get(initial_response.url)
+
+    assert response.context['results']['hits']['total'] == 5
+
+    initial_response = client.get('/search?text_query=Esmeé')
+    response = client.get(initial_response.url)
+
+    assert response.context['results']['hits']['total'] == 5
 
 
 def test_stats(provenance_dataload, client):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import Select
 
 from dataload.import_to_elasticsearch import import_to_elasticsearch
 
@@ -109,6 +110,33 @@ def test_search(provenance_dataload, server_url, browser):
     other_currencies_modal.click()
     time.sleep(0.5)
     assert "$146,325" in browser.find_element_by_tag_name('body').text
+
+
+def test_search_by_only_titles_and_descriptions_radio_button_in_home(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+
+    assert "Only Titles & Descriptions" in browser.find_element_by_tag_name('body').text
+
+
+def test_search_by_only_titles_and_descriptions_radio_button_in_search(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert "Only Titles & Descriptions" in browser.find_element_by_tag_name('body').text
+
+
+def test_search_by_only_titles_and_descriptions(provenance_dataload, server_url, browser):
+    browser.get(server_url)
+    # select title_and_description from dropdown menu
+    search_dropdown = Select(browser.find_element_by_class_name("front_search"))
+    search_dropdown.select_by_value("title_and_description")
+    # search "laboratory"
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('laboratory')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert "New science laboratory" in browser.find_element_by_tag_name('body').text
+    assert "laboratories" not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_current_url(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -136,7 +136,22 @@ def test_search_by_titles_and_descriptions(provenance_dataload, server_url, brow
     browser.find_element_by_class_name("large-search-icon").click()
 
     assert "New science laboratory" in browser.find_element_by_tag_name('body').text
-    assert "laboratories" not in browser.find_element_by_tag_name('body').text
+    assert "laboratories" in browser.find_element_by_tag_name('body').text
+    assert "£4,846,774" in browser.find_element_by_tag_name('body').text
+    # result in "Search All" query
+    assert "£4,991,774" not in browser.find_element_by_tag_name('body').text
+
+    browser.get(server_url)
+    # search "laboratory" in "Search All"
+    search_box = browser.find_element_by_class_name("large-search")
+    search_box.send_keys('laboratory')
+    browser.find_element_by_class_name("large-search-icon").click()
+
+    assert "New science laboratory" in browser.find_element_by_tag_name('body').text
+    assert "laboratories" in browser.find_element_by_tag_name('body').text
+    assert "£4,991,774" in browser.find_element_by_tag_name('body').text
+    # result in "Titles and Descriptions" query.
+    assert "£4,846,774" not in browser.find_element_by_tag_name('body').text
 
 
 def test_search_current_url(provenance_dataload, server_url, browser):

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -112,20 +112,20 @@ def test_search(provenance_dataload, server_url, browser):
     assert "$146,325" in browser.find_element_by_tag_name('body').text
 
 
-def test_search_by_only_titles_and_descriptions_radio_button_in_home(provenance_dataload, server_url, browser):
+def test_search_by_titles_and_descriptions_radio_button_in_home(provenance_dataload, server_url, browser):
     browser.get(server_url)
 
-    assert "Only Titles & Descriptions" in browser.find_element_by_tag_name('body').text
+    assert "Titles & Descriptions" in browser.find_element_by_tag_name('body').text
 
 
-def test_search_by_only_titles_and_descriptions_radio_button_in_search(provenance_dataload, server_url, browser):
+def test_search_by_titles_and_descriptions_radio_button_in_search(provenance_dataload, server_url, browser):
     browser.get(server_url)
     browser.find_element_by_class_name("large-search-icon").click()
 
-    assert "Only Titles & Descriptions" in browser.find_element_by_tag_name('body').text
+    assert "Titles & Descriptions" in browser.find_element_by_tag_name('body').text
 
 
-def test_search_by_only_titles_and_descriptions(provenance_dataload, server_url, browser):
+def test_search_by_titles_and_descriptions(provenance_dataload, server_url, browser):
     browser.get(server_url)
     # select title_and_description from dropdown menu
     search_dropdown = Select(browser.find_element_by_class_name("front_search"))


### PR DESCRIPTION
Relates to #479 

Add extra search option by 'Only titles and descriptions'

<img width="556" alt="screen shot 2018-08-31 at 14 08 06" src="https://user-images.githubusercontent.com/9610927/44920193-27f56400-ad37-11e8-80b0-ef5bb8842393.png">

<img width="1344" alt="screen shot 2018-08-31 at 15 56 19" src="https://user-images.githubusercontent.com/9610927/44919915-8241f500-ad36-11e8-9e16-2d1769cff07b.png">
<img width="1222" alt="screen shot 2018-08-31 at 15 56 35" src="https://user-images.githubusercontent.com/9610927/44919919-853ce580-ad36-11e8-8b32-d9db03ddb0aa.png">
