### PR TITLE
Add help link for £0 grants

### DIFF
--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -62,7 +62,15 @@
           <table class="table table-bordered">
             <tbody>
               {% for key, grant in grant.source|flatten %}
-              <tr> <td style="width: 40%"> <b>{{ key }} </b> </td> <td> {{grant}} </td>
+              <tr> 
+                <td style="width: 40%"> <b>{{ key }}</b> 
+                </td> 
+                <td> 
+                  {{grant}}
+                  {% if key == "Amount Awarded" and grant == 0 %}
+                    <a href="/help#zero_value_grants"><img src="/static/images/icon-help-50.png" width="15" height="15"></a>
+                  {% endif %} 
+                </td>
               {% endfor %}
             </tbody>
           </table>

--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -68,7 +68,7 @@
                 <td> 
                   {{grant}}
                   {% if key == "Amount Awarded" and grant == 0 %}
-                    <a href="/help#zero_value_grants"><img src="/static/images/icon-help-50.png" width="15" height="15"></a>
+                    <a href="/help#zero_value_grants"><img src="/static/images/icon-help-50.png" width="15" height="15" id="zero_value_grant_help_link"></a>
                   {% endif %} 
                 </td>
               {% endfor %}

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -302,7 +302,11 @@
                 <div class="col-xs-6">
                   <div class="panel panel-default">
                     <div class="panel-body">
-                      <b>Amount: </b> {{result.source|get_currency}}{{result.source.amountAwarded|get_amount}} <br/>
+                      <b>Amount: </b> {{result.source|get_currency}}{{result.source.amountAwarded|get_amount}}
+                      {% if result.source.amountAwarded|get_amount == '0' %}
+                        <a href="/help#zero_value_grants"><img src="/static/images/icon-help-50.png" width="15" height="15"></a>
+                      {% endif %}
+                      <br/>
                       <b>Funder: </b> <a href="{% url 'funder' result.source.fundingOrganization.0.id %}">{{ result.source.fundingOrganization.0 | get_name }}</a> <br/>
                       <b>Recipient: </b> <a href="{% url 'recipient' result.source.recipientOrganization.0.id %}">{{ result.source.recipientOrganization.0|get_name|truncatechars:40 }} </a> <br/>
                       {% if result.source.recipientRegionName %}

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -418,3 +418,16 @@ def test_currency_facet(provenance_dataload, server_url, browser):
     browser.find_element_by_class_name("large-search-icon").click()
     browser.find_element_by_link_text("USD (4)").click()
     assert 'USD 0 - USD 500' in browser.find_element_by_tag_name('body').text
+
+
+@pytest.mark.parametrize(('path'), ['/grant/360G-wolfson-19916'])
+def test_zero_grant_info_link_present(provenance_dataload, server_url, browser, path):
+    browser.get(server_url + path)
+    browser.find_element_by_id("zero_value_grant_help_link").click()
+    assert browser.current_url == server_url + '/help#zero_value_grants'
+
+
+@pytest.mark.parametrize(('path'), ['/grant/360G-LBFEW-99233'])
+def test_zero_grant_info_link_absent(provenance_dataload, server_url, browser, path):
+    browser.get(server_url + path)
+    assert len(browser.find_elements_by_id('zero_value_grant_help_link')) == 0


### PR DESCRIPTION
@morchickit last GN PR! This adds the info link to £0 grants from #410 . Are you happy for us to merge this and get it live? The (i) links to the £0 part of the help page

![screenshot 2018-12-13 at 11 46 05](https://user-images.githubusercontent.com/641009/49936757-b1870700-fecc-11e8-9d7e-fbf054de2331.png)
